### PR TITLE
Fixed error in CF image resize URLs

### DIFF
--- a/classes/cloudflare-image-resize/cloudflare-image-resizing.php
+++ b/classes/cloudflare-image-resize/cloudflare-image-resizing.php
@@ -217,9 +217,9 @@ class Cloudflare_Image_Resize {
 	private function implode_parameters($cf_params) {
 		$cf_param_array = [];
 		foreach ( $cf_params as $key => $value ) {
-			$cf_param_array[] = $key . '=' . $value;
+            $cf_param_array[] = $key . '=' . $value;
 		}
-		return implode(',', $cf_params);
+		return implode(',', $cf_param_array);
 	}
 
 	/**


### PR DESCRIPTION
The Cloudflare Image Resize feature was not working due to invalid arguments in the URL.