### PR TITLE
WPSO-54 Make cache purge AJAX calls work with new cache purge driver

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,7 +48,6 @@
     "key-spacing": "error",
     "keyword-spacing": "error",
     "lines-around-comment": "off",
-    "no-alert": "error",
     "no-bitwise": "error",
     "no-caller": "error",
     "no-console": "off",

--- a/admin/admin-bar-interface.php
+++ b/admin/admin-bar-interface.php
@@ -90,7 +90,9 @@ class Servebolt_Admin_Bar_Interface {
 			];
 		}
 
-		if ( is_network_admin() ) {
+		if (is_network_admin() ) {
+		    // TODO: Re-introduce this feature
+		    /*
 			$nodes[] = [
 				'id'    => 'servebolt-clear-cf-network-cache',
 				'title' => sb__('Purge Cloudflare Cache for all sites'),
@@ -100,6 +102,7 @@ class Servebolt_Admin_Bar_Interface {
 					'class' => 'sb-admin-button sb-purge-network-cache'
 				]
 			];
+		    */
 		}
 
         $cache_purge_available = sb_cf_cache()->should_use_cf_feature();

--- a/assets/src/js/cloudflare-cache-purge-trigger.js
+++ b/assets/src/js/cloudflare-cache-purge-trigger.js
@@ -1,11 +1,13 @@
 jQuery(document).ready(function($) {
 
   // Purge all cache on all sites in a multisite-network
+  /*
   $('.sb-purge-network-cache').click(function (e) {
     e.preventDefault();
     sb_close_admin_bar_menu();
     sb_purge_network_cache();
   });
+  */
 
   // Purge all cache
   $('#sb-configuration .sb-purge-all-cache, #wpadminbar .sb-purge-all-cache').click(function (e) {
@@ -178,7 +180,9 @@ jQuery(document).ready(function($) {
           }, 100);
           return;
         }
-        window.handle_unsuccessful_cache_purge(response);
+        sb_cache_purge_error();
+        // TODO: Display errors to the user
+        //window.handle_unsuccessful_cache_purge(response);
       },
       error: function() {
         window.sb_loading(false);
@@ -188,23 +192,33 @@ jQuery(document).ready(function($) {
   };
 
   window.handle_unsuccessful_cache_purge = function(response) {
-    sb_cache_purge_error();
-    return;
     var type = window.sb_get_from_response(response, 'type', 'error'),
         message = window.sb_get_message_from_response(response);
     if (message) {
       // TODO: Display single message
       return;
+      switch(type) {
+        case 'error':
+          sb_cache_purge_error();
+          break;
+        case 'warning':
+          sb_cache_purge_warning();
+          break;
+      }
     }
     var messages = window.sb_get_messages_from_response(response);
     if (messages) {
       // TODO: Handle multiple messages
       return;
+      switch(type) {
+        case 'error':
+          sb_cache_purge_error();
+          break;
+        case 'warning':
+          sb_cache_purge_warning();
+          break;
+      }
     }
-
-
-
-    alert('Fail');
     /*
     var type = window.sb_get_from_response(response, 'type');
     if ( type == 'warning' ) {
@@ -271,24 +285,29 @@ jQuery(document).ready(function($) {
       data: data,
       success: function(response) {
         window.sb_loading(false);
-        var title = window.sb_get_from_response(response, 'title'),
-            message = window.sb_get_message_from_response(response);
         if ( response.success ) {
           setTimeout(function () {
-            sb_cache_purge_success(message, title);
+            sb_cache_purge_success(
+                window.sb_get_message_from_response(response),
+                window.sb_get_from_response(response, 'title')
+            );
             window.update_cache_purge_list();
           }, 100);
-        } else {
-          if ( message ) {
-            if ( response.data.type == 'warning' ) {
-              window.sb_warning(title, null, message);
-            } else {
-              sb_cache_purge_error(message);
-            }
-          } else {
-            sb_cache_purge_error();
-          }
+          return;
         }
+        sb_cache_purge_error();
+        // TODO: Display errors to the user
+        /*
+        if ( message ) {
+          if ( response.data.type == 'warning' ) {
+            window.sb_warning(title, null, message);
+          } else {
+            sb_cache_purge_error(message);
+          }
+        } else {
+
+        }
+        */
       },
       error: function() {
         window.sb_loading(false);
@@ -350,20 +369,19 @@ jQuery(document).ready(function($) {
       data: data,
       success: function(response) {
         window.sb_loading(false);
-
-        var title = window.sb_get_from_response(response, 'title'),
-            message = window.sb_get_message_from_response(response);
-
         if (response.success) {
           setTimeout(function() {
+            var title = window.sb_get_from_response(response, 'title'),
+                message = window.sb_get_message_from_response(response);
             sb_cache_purge_success(message, title);
             window.update_cache_purge_list();
           }, 100);
           return;
         }
-
+        sb_cache_purge_error();
+        // TODO: Display errors to the user
+        /*
         return;
-
         if ( message ) {
           if ( response.data.type == 'warning' ) {
             window.sb_warning(title, null, message);
@@ -373,6 +391,7 @@ jQuery(document).ready(function($) {
         } else {
           sb_cache_purge_error();
         }
+        */
       },
       error: function() {
         window.sb_loading(false);
@@ -419,10 +438,16 @@ jQuery(document).ready(function($) {
    * @param title
    */
   function sb_cache_purge_error(message, include_url_message, title) {
-    if ( typeof include_url_message === 'undefined' ) include_url_message = true;
-    if ( typeof title === 'undefined' || ! title ) title = 'Unknown error';
-    var generic_message = 'Something went wrong. Please check that you:<br><ul style="text-align: left;max-width:350px;margin: 20px auto;">' + ( include_url_message ? '<li>- Specified a valid URL</li>' : '' ) + '<li>- Have added valid API credentials</li><li>- Have selected an active zone</li></ul> If the error still persist then please check the error logs and/or contact support.';
-    window.sb_error(title, null, ( message ? message : generic_message ));
+    if ( typeof include_url_message === 'undefined' ) {
+      include_url_message = true;
+    }
+    if ( typeof title === 'undefined' || ! title ) {
+      title = 'Unknown error';
+    }
+    if (!message) {
+      var message = 'Something went wrong. Please check that you:<br><ul style="text-align: left;max-width:350px;margin: 20px auto;">' + ( include_url_message ? '<li>- Specified a valid URL</li>' : '' ) + '<li>- Have configured the cache purge feature</li></ul> If the error still persist then please check the error logs and/or contact support.';
+    }
+    window.sb_error(title, null, message);
   }
 
 });

--- a/assets/src/js/cloudflare-cache-purge.js
+++ b/assets/src/js/cloudflare-cache-purge.js
@@ -127,12 +127,12 @@ jQuery(document).ready(function($) {
     var auth_type = $('#sb-configuration input[name="servebolt_cf_auth_type"]:checked').val();
     switch (auth_type) {
       case 'api_token':
-        var api_token = $('#sb-configuration #sb_api_token').val();
+        var api_token = $('#sb-configuration #sb_cf_api_token').val();
         return api_token != '';
         break;
       case 'api_key':
-        var email = $('#sb-configuration #sb_email').val(),
-          api_key = $('#sb-configuration #sb_api_key').val();
+        var email = $('#sb-configuration #sb_cf_email').val(),
+          api_key = $('#sb-configuration #sb_cf_api_key').val();
         return email != '' && api_key != '';
         break;
     }
@@ -291,7 +291,7 @@ jQuery(document).ready(function($) {
     var auth_type = $('#sb-configuration input[name="servebolt_cf_auth_type"]:checked').val();
     switch (auth_type) {
       case 'api_token':
-        var api_token = $('#sb-configuration #sb_api_token').val();
+        var api_token = $('#sb-configuration #sb_cf_api_token').val();
         if ( api_token ) {
           api_credentials_zone_lookup_type_wait_timeout = setTimeout(function () {
             fetch_and_display_available_zones(auth_type, { apiToken: api_token });
@@ -301,8 +301,8 @@ jQuery(document).ready(function($) {
         }
         break;
       case 'api_key':
-        var email = $('#sb-configuration #sb_email').val(),
-          api_key = $('#sb-configuration #sb_api_key').val();
+        var email = $('#sb-configuration #sb_cf_email').val(),
+          api_key = $('#sb-configuration #sb_cf_api_key').val();
         if ( email && api_key ) {
           api_credentials_zone_lookup_type_wait_timeout = setTimeout(function () {
             fetch_and_display_available_zones(auth_type, { email: email, apiKey: api_key });
@@ -329,15 +329,15 @@ jQuery(document).ready(function($) {
       case 'api_key':
         api_token_container.hide();
         api_key_container.show();
-        var email = $('#sb-configuration #sb_email').val(),
-          api_key = $('#sb-configuration #sb_api_key').val();
+        var email = $('#sb-configuration #sb_cf_email').val(),
+          api_key = $('#sb-configuration #sb_cf_api_key').val();
         fetch_and_display_available_zones(auth_type, { email: email, api_key: api_key });
         break;
       case 'api_token':
         api_token_container.show();
         api_key_container.hide();
         zone_selector_container.hide();
-        var api_token = $('#sb-configuration #sb_api_token').val();
+        var api_token = $('#sb-configuration #sb_cf_api_token').val();
         fetch_and_display_available_zones(auth_type, { api_token: api_token });
     }
     sb_resolve_zone_name();
@@ -352,13 +352,13 @@ jQuery(document).ready(function($) {
     var auth_type = $('#sb-configuration input[name="servebolt_cf_auth_type"]:checked').val();
     switch (auth_type) {
       case 'api_key':
-        var api_token_element = $('#sb-configuration .feature_cf_auth_type-api_token #sb_api_token');
+        var api_token_element = $('#sb-configuration .feature_cf_auth_type-api_token #sb_cf_api_token');
         api_token_element.val(api_token_element.data('original-value'));
         break;
       case 'api_token':
         var api_key_container = $('#sb-configuration .feature_cf_auth_type-api_key'),
-          api_key_element = api_key_container.find('#sb_api_key'),
-          email_element = api_key_container.find('#sb_email');
+          api_key_element = api_key_container.find('#sb_cf_api_key'),
+          email_element = api_key_container.find('#sb_cf_email');
         api_key_element.val(api_key_element.data('original-value'));
         email_element.val(email_element.data('original-value'));
         break;
@@ -480,8 +480,8 @@ jQuery(document).ready(function($) {
    * @param obj
    */
   function remove_purge_item(obj) {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want to remove the item?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want to remove the item?')) {
         remove_purge_item_confirmed(obj);
       }
     } else {
@@ -520,8 +520,8 @@ jQuery(document).ready(function($) {
    * Remove selected purge items from purge queue.
    */
   function remove_selected_purge_items() {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want remove the selected items?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want remove the selected items?')) {
         remove_selected_purge_items_confirmed();
       }
     } else {
@@ -572,8 +572,8 @@ jQuery(document).ready(function($) {
    * Flush cache purge queue.
    */
   function flush_purge_queue() {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want to empty cache purge queue?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want to empty cache purge queue?')) {
         flush_purge_queue_confirmed();
       }
     } else {

--- a/assets/src/js/fpc.js
+++ b/assets/src/js/fpc.js
@@ -46,8 +46,8 @@ jQuery(document).ready(function($) {
    * @param obj
    */
   function sb_remove_exclude_item(obj) {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want to remove the item?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want to remove the item?')) {
         sb_remove_exclude_item_confirmed(obj);
       }
     } else {
@@ -88,8 +88,8 @@ jQuery(document).ready(function($) {
    * Flush FPC post exclude list.
    */
   function sb_flush_fpc_exclude_list() {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want to remove all posts from exclude list?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want to remove all posts from exclude list?')) {
         sb_flush_fpc_exclude_list_confirmed();
       }
     } else {
@@ -126,8 +126,8 @@ jQuery(document).ready(function($) {
    * Remove selected post from FPC exclude list.
    */
   function sb_remove_selected_exclude_items() {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want remove the selected items?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want remove the selected items?')) {
         sb_remove_selected_exclude_items_confirmed();
       }
     } else {
@@ -172,9 +172,9 @@ jQuery(document).ready(function($) {
    */
   function sb_add_posts_to_fpc_exclude() {
     if ( window.sb_use_native_js_fallback() ) {
-      var value = prompt('Add posts to list' + "\n" + 'Insert the IDs (comma separated) of the post you would like to exclude from the cache');
+      var value = window.prompt('Add posts to list' + "\n" + 'Insert the IDs (comma separated) of the post you would like to exclude from the cache');
       if ( ! value ) {
-        alert('Please enter a post ID.');
+        window.alert('Please enter a post ID.');
         return;
       }
       sb_add_posts_to_fpc_exclude_confirmed(value);

--- a/assets/src/js/general.js
+++ b/assets/src/js/general.js
@@ -105,7 +105,7 @@ jQuery(document).ready(function($) {
     if ( window.sb_use_native_js_fallback() ) {
       var verboseType = type.charAt(0).toUpperCase() + type.slice(1);
       var message = html ? window.sb_strip(html, true) : window.sb_strip(text);
-      alert(verboseType + ': ' + window.sb_strip(title) + "\n" + message);
+      window.alert(verboseType + ': ' + window.sb_strip(title) + "\n" + message);
     } else {
       var config = {
         icon: type,
@@ -141,7 +141,7 @@ jQuery(document).ready(function($) {
     }
     var doc = new DOMParser().parseFromString(html, 'text/html');
     return doc.body.textContent || '';
-  }
+  };
 
   /**
    * Get message from jQuery AJAX response object.
@@ -150,7 +150,17 @@ jQuery(document).ready(function($) {
    * @returns {*}
    */
   window.sb_get_message_from_response = function(response) {
-    return window.sb_get_from_response(response, 'message')
+    return window.sb_get_from_response(response, 'message');
+  };
+
+  /**
+   * Get message from jQuery AJAX response object.
+   *
+   * @param response
+   * @returns {*}
+   */
+  window.sb_get_messages_from_response = function(response) {
+    return window.sb_get_from_response(response, 'messages');
   }
 
   /**
@@ -158,14 +168,14 @@ jQuery(document).ready(function($) {
    *
    * @param response
    * @param key
-   * @param default_value
+   * @param defaultValue
    * @returns {*}
    */
-  window.sb_get_from_response = function(response, key, default_value) {
+  window.sb_get_from_response = function(response, key, defaultValue) {
     if ( typeof response.data !== 'undefined' && typeof response.data[key] !== 'undefined' ) {
       return response.data[key];
     }
-    return default_value ? default_value : false;
+    return defaultValue ? defaultValue : false;
   }
 
   /**

--- a/assets/src/js/performance-checks.js
+++ b/assets/src/js/performance-checks.js
@@ -34,8 +34,8 @@ jQuery(document).ready(function($) {
    * Run full optimization.
    */
   function sb_optimize() {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'This will add any missing indexes and convert all tables to use modern storage engines.') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'This will add any missing indexes and convert all tables to use modern storage engines.')) {
         sb_optimize_confirmed();
       }
     } else {
@@ -99,7 +99,7 @@ jQuery(document).ready(function($) {
           message += "\n" + '- ' + window.sb_strip(task);
         });
       }
-      alert('All good!' + message);
+      window.alert('All good!' + message);
       location.reload();
     } else {
       var message = response.data.message;
@@ -129,9 +129,9 @@ jQuery(document).ready(function($) {
    * Debug function to remove indexes and change DB engine.
    */
   function sb_deoptimize() {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'WARNING: This functionality is added for development purposes and will remove indexes and convert table engines to MyISAM. This is not something you really want unless you are debugging/developing. Do you want to proceed?') ) {
-        if ( confirm('Are you sure?' + "\n" + 'Last warning? You really want to proceed?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'WARNING: This functionality is added for development purposes and will remove indexes and convert table engines to MyISAM. This is not something you really want unless you are debugging/developing. Do you want to proceed?')) {
+        if (window.confirm('Are you sure?' + "\n" + 'Last warning? You really want to proceed?')) {
           sb_deoptimize_confirmed();
         }
       }
@@ -173,7 +173,7 @@ jQuery(document).ready(function($) {
    */
   function sb_deoptimize_confirmed_success() {
     if ( window.sb_use_native_js_fallback() ) {
-      alert('All good!');
+      window.alert('All good!');
       location.reload();
     } else {
       Swal.fire({
@@ -194,7 +194,7 @@ jQuery(document).ready(function($) {
    */
   function sb_deoptimize_confirmed_error() {
     if ( window.sb_use_native_js_fallback() ) {
-      alert('Ouch, we got an error' + "\n" + 'Unknown error');
+      window.alert('Ouch, we got an error' + "\n" + 'Unknown error');
     } else {
       Swal.fire({
         icon: 'error',
@@ -236,10 +236,12 @@ jQuery(document).ready(function($) {
 
   /**
    * Convert a table to InnoDB.
+   *
+   * @param element
    */
   function sb_convert_table(element) {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want to convert the table?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want to convert the table?')) {
         sb_convert_table_confirmed(element);
       }
     } else {
@@ -254,7 +256,7 @@ jQuery(document).ready(function($) {
         },
         buttonsStyling: false
       }).then((result) => {
-        if ( result.value ) {
+        if (result.value) {
           sb_convert_table_confirmed(element);
         }
       });
@@ -267,8 +269,8 @@ jQuery(document).ready(function($) {
    * @param message
    */
   function sb_convert_table_confirmed_success(message) {
-    if ( window.sb_use_native_js_fallback() ) {
-      alert('All good!' + "\n" + window.sb_strip(message, true));
+    if (window.sb_use_native_js_fallback()) {
+      window.alert('All good!' + "\n" + window.sb_strip(message, true));
       location.reload();
     } else {
       Swal.fire({
@@ -321,10 +323,12 @@ jQuery(document).ready(function($) {
 
   /**
    * Create index on table.
+   *
+   * @param element
    */
   function sb_create_index(element) {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Do you really want to create index?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Do you really want to create index?')) {
         sb_create_index_confirmed(element);
       }
     } else {
@@ -353,7 +357,7 @@ jQuery(document).ready(function($) {
    */
   function sb_create_index_confirmed_success(message) {
     if ( window.sb_use_native_js_fallback() ) {
-      alert('All good!' + "\n" + window.sb_strip(message, true));
+      window.alert('All good!' + "\n" + window.sb_strip(message, true));
       location.reload();
     } else {
       Swal.fire({
@@ -408,9 +412,9 @@ jQuery(document).ready(function($) {
    * Clear all plugin settings.
    */
   function sb_clear_all_settings() {
-    if ( window.sb_use_native_js_fallback() ) {
-      if ( confirm('Are you sure?' + "\n" + 'Warning: this will clear all settings and essentially reset the whole plugin. You want to proceed?') ) {
-        if ( confirm('Last warning' + "\n" + 'Do you really want to proceed?') ) {
+    if (window.sb_use_native_js_fallback()) {
+      if (window.confirm('Are you sure?' + "\n" + 'Warning: this will clear all settings and essentially reset the whole plugin. You want to proceed?')) {
+        if (window.confirm('Last warning' + "\n" + 'Do you really want to proceed?')) {
           sb_clear_all_settings_confirmed();
         }
       }
@@ -474,7 +478,7 @@ jQuery(document).ready(function($) {
    */
   function sb_clear_all_settings_confirmed_success() {
     if ( window.sb_use_native_js_fallback() ) {
-      alert('Done!');
+      window.alert('Done!');
       location.reload();
     } else {
       Swal.fire({

--- a/src/Servebolt/Admin/Ajax/CachePurge/Configuration.php
+++ b/src/Servebolt/Admin/Ajax/CachePurge/Configuration.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 use Servebolt\Optimizer\Admin\Ajax\SharedMethods;
 use Servebolt\Optimizer\Sdk\Cloudflare\Cloudflare as CloudflareSdk;
+use Exception;
 
 class Configuration extends SharedMethods
 {

--- a/src/Servebolt/Admin/Ajax/CachePurge/Configuration.php
+++ b/src/Servebolt/Admin/Ajax/CachePurge/Configuration.php
@@ -101,10 +101,10 @@ class Configuration extends SharedMethods
         parse_str($_POST['form'], $form_data);
         $errors = [];
 
-        $featureIsActive = array_key_exists('cache_purge_switch', $form_data)
-            && filter_var($form_data['cache_purge_switch'], FILTER_VALIDATE_BOOLEAN) === true;
-        $cfIsActive = array_key_exists('cache_purge_driver', $form_data)
-            && $form_data['cache_purge_driver'] == 'cloudflare';
+        $featureIsActive = array_key_exists('servebolt_cache_purge_switch', $form_data)
+            && filter_var($form_data['servebolt_cache_purge_switch'], FILTER_VALIDATE_BOOLEAN) === true;
+        $cfIsActive = array_key_exists('servebolt_cache_purge_driver', $form_data)
+            && $form_data['servebolt_cache_purge_driver'] == 'cloudflare';
         $authType = sanitize_text_field($form_data['servebolt_cf_auth_type']);
         $apiToken = sanitize_text_field($form_data['servebolt_cf_api_token']);
         $email = sanitize_text_field($form_data['servebolt_cf_email']);
@@ -126,7 +126,7 @@ class Configuration extends SharedMethods
                         'credentials' => compact('apiToken')
                     ]);
                     try {
-                        if ( ! $cfSdk->verifyToken() ) {
+                        if (!$cfSdk->verifyApiToken()) {
                             throw new Exception;
                         }
                         $shouldCheckZone = true;
@@ -136,15 +136,15 @@ class Configuration extends SharedMethods
                 }
                 break;
             case 'api_key':
-                if ( empty($email) ) {
+                if (empty($email)) {
                     $errors['email'] = sb__('You need to provide an email address.');
                 }
 
-                if ( empty($apiKey) ) {
+                if (empty($apiKey)) {
                     $errors['api_key'] = sb__('You need to provide an API key.');
                 }
 
-                if ( ! empty($email) && ! empty($apiKey) ) {
+                if (!empty($email) && !empty($apiKey)) {
                     $cfSdk = new CloudflareSdk([
                         'authType' => 'api_key',
                         'credentials' => compact('email', 'apiKey')

--- a/src/Servebolt/Admin/Ajax/CachePurge/PurgeActions.php
+++ b/src/Servebolt/Admin/Ajax/CachePurge/PurgeActions.php
@@ -18,9 +18,11 @@ class PurgeActions extends SharedMethods
         add_action('wp_ajax_servebolt_purge_all_cache', [$this, 'purgeAllCacheCallback']);
         add_action('wp_ajax_servebolt_purge_url_cache', [$this, 'purgeUrlCacheCallback']);
         add_action('wp_ajax_servebolt_purge_post_cache', [$this, 'purgePostCacheCallback']);
+        /*
         if ( is_multisite() ) {
             add_action('wp_ajax_servebolt_purge_network_cache', [$this, 'purgeNetworkCacheCallback']);
         }
+        */
     }
 
     /**
@@ -139,6 +141,7 @@ class PurgeActions extends SharedMethods
     /**
      * Purge all Cloudflare cache in all sites in multisite-network.
      */
+    /*
     public function purgeNetworkCacheCallback() : void
     {
         $this->checkAjaxReferer();
@@ -226,6 +229,7 @@ class PurgeActions extends SharedMethods
             }
         }
     }
+    */
 
     /**
      * Handle the "item already in the queue".
@@ -261,6 +265,7 @@ class PurgeActions extends SharedMethods
      *
      * @return string
      */
+    /*
     private function purgeNetworkCacheFailedSites($failed): string
     {
         $markup = '<strong>' . sb__('The cache was cleared on all sites except the following:') . '</strong>';
@@ -269,4 +274,5 @@ class PurgeActions extends SharedMethods
         });
         return $markup;
     }
+    */
 }

--- a/src/Servebolt/Admin/Ajax/CachePurge/PurgeActions.php
+++ b/src/Servebolt/Admin/Ajax/CachePurge/PurgeActions.php
@@ -4,8 +4,10 @@ namespace Servebolt\Optimizer\Admin\Ajax\CachePurge;
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
+use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
 use Servebolt\Optimizer\CachePurge\CachePurge;
 use Servebolt\Optimizer\Admin\Ajax\SharedMethods;
+use Exception;
 
 class PurgeActions extends SharedMethods
 {
@@ -28,26 +30,36 @@ class PurgeActions extends SharedMethods
     /**
      * Purge all cache cache.
      */
-    public function purgeAllCacheCallback() : void
+    public function purgeAllCacheCallback()
     {
         $this->checkAjaxReferer();
         sb_ajax_user_allowed();
         $cronPurgeIsActive = CachePurge::cronPurgeIsActive();
-        $i = CachePurge::getInstance();
         $hasPurgeAllRequestInQueue = false; // TODO: Check if there is already a purge all request in the queue, if the cron feature is active.
+
         if (!CachePurge::cachePurgeIsActive()) {
             wp_send_json_error( [ 'message' => 'The cache purge feature is not active so we could not purge cache. Make sure you the configuration is correct.' ] );
-        } elseif ($cronPurgeIsActive && $hasPurgeAllRequestInQueue) {
+            return;
+        }
+
+        if ($cronPurgeIsActive && $hasPurgeAllRequestInQueue) {
             wp_send_json_success([
                 'title' => 'All good!',
                 'message' => 'A purge all-request is already queued and should be executed shortly.',
             ]);
-        } elseif ($i->purgeAll()) {
-            wp_send_json_success( [
-                'title'   => $cronPurgeIsActive ? 'Just a moment' : false,
-                'message' => $cronPurgeIsActive ? 'A purge all-request was added to the queue and will be executed shortly.' : 'All cache was purged.',
-            ] );
-        } else {
+            return;
+        }
+
+        try {
+            if (WordPressCachePurge::purgeAll()) {
+                wp_send_json_success( [
+                    'title'   => $cronPurgeIsActive ? 'Just a moment' : false,
+                    'message' => $cronPurgeIsActive ? 'A purge all-request was added to the queue and will be executed shortly.' : 'All cache was purged.',
+                ] );
+                return;
+            }
+        } catch (Exception $e) {
+            // TODO: Get error messages
             wp_send_json_error();
         }
     }
@@ -73,8 +85,7 @@ class PurgeActions extends SharedMethods
         }
 
         $cronPurgeIsActive = CachePurge::cronPurgeIsActive();
-        $i = CachePurge::getInstance();
-        $purgeResult = $i->purgeByUrl($url);
+        $purgeResult = WordPressCachePurge::purgeByUrl($url);
 
         if ($purgeResult === false) {
             wp_send_json_error(); // Unspecified error
@@ -116,13 +127,12 @@ class PurgeActions extends SharedMethods
         }
 
         $cronPurgeIsActive = CachePurge::cronPurgeIsActive();
-        $i = CachePurge::getInstance();
-        $purgeResult = $i->purgeByPost($postId);
+        $purgeResult = WordPressCachePurge::purgeByPost($postId);
 
         if ($purgeResult === false) {
             wp_send_json_error(); // Unspecified error
             return;
-        } elseif ( is_wp_error($purgeResult) ) {
+        } elseif (is_wp_error($purgeResult)) {
             $this->handlePurgeItemAlreadyInQueue($purgeResult);
             return;
         }

--- a/src/Servebolt/Admin/Ajax/CachePurge/PurgeActions.php
+++ b/src/Servebolt/Admin/Ajax/CachePurge/PurgeActions.php
@@ -8,6 +8,7 @@ use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
 use Servebolt\Optimizer\CachePurge\CachePurge;
 use Servebolt\Optimizer\Admin\Ajax\SharedMethods;
 use Exception;
+use Servebolt\Optimizer\Exceptions\ApiError;
 
 class PurgeActions extends SharedMethods
 {
@@ -21,10 +22,21 @@ class PurgeActions extends SharedMethods
         add_action('wp_ajax_servebolt_purge_url_cache', [$this, 'purgeUrlCacheCallback']);
         add_action('wp_ajax_servebolt_purge_post_cache', [$this, 'purgePostCacheCallback']);
         /*
+        // TODO: Make this feature work with the new cache purge driver
         if ( is_multisite() ) {
             add_action('wp_ajax_servebolt_purge_network_cache', [$this, 'purgeNetworkCacheCallback']);
         }
         */
+    }
+
+    /**
+     * Ensure that the cache purge feature is active, unless send an error response.
+     */
+    private function ensureCachePurgeFeatureIsActive(): void
+    {
+        if (!CachePurge::cachePurgeIsActive()) {
+            wp_send_json_error(['message' => 'The cache purge feature is not active so we could not purge cache. Make sure you the configuration is correct.']);
+        }
     }
 
     /**
@@ -34,13 +46,11 @@ class PurgeActions extends SharedMethods
     {
         $this->checkAjaxReferer();
         sb_ajax_user_allowed();
+
+        $this->ensureCachePurgeFeatureIsActive();
+
         $cronPurgeIsActive = CachePurge::cronPurgeIsActive();
         $hasPurgeAllRequestInQueue = false; // TODO: Check if there is already a purge all request in the queue, if the cron feature is active.
-
-        if (!CachePurge::cachePurgeIsActive()) {
-            wp_send_json_error( [ 'message' => 'The cache purge feature is not active so we could not purge cache. Make sure you the configuration is correct.' ] );
-            return;
-        }
 
         if ($cronPurgeIsActive && $hasPurgeAllRequestInQueue) {
             wp_send_json_success([
@@ -51,19 +61,23 @@ class PurgeActions extends SharedMethods
         }
 
         try {
-            if (WordPressCachePurge::purgeAll()) {
+            WordPressCachePurge::purgeAll();
+            if ($cronPurgeIsActive) {
                 wp_send_json_success( [
-                    'title'   => $cronPurgeIsActive ? 'Just a moment' : false,
-                    'message' => $cronPurgeIsActive ? 'A purge all-request was added to the queue and will be executed shortly.' : 'All cache was purged.',
+                    'title' => 'Just a moment',
+                    'message' => 'A purge all-request was added to the queue and will be executed shortly.',
                 ] );
-                return;
             } else {
-                wp_send_json_error();
+                wp_send_json_success(['message' => 'All cache was purged.']);
+            }
+        } catch (ApiError $e) {
+            if ($e->hasMultipleErrors()) {
+                wp_send_json_error($e->getErrors());
+            } else {
+                wp_send_json_error(['message' => $e->getMessage()]);
             }
         } catch (Exception $e) {
-            // TODO: Catch client errors from HTTP client
-            // TODO: Catch exceptions from API errors
-            wp_send_json_error();
+            wp_send_json_error(['message' => $e->getMessage()]);
         }
     }
 
@@ -75,13 +89,9 @@ class PurgeActions extends SharedMethods
         $this->checkAjaxReferer();
         sb_ajax_user_allowed();
 
+        $this->ensureCachePurgeFeatureIsActive();
+
         $url = (string) sb_array_get('url', $_POST);
-
-        if (!CachePurge::cachePurgeIsActive()) {
-            wp_send_json_error( [ 'message' => sb__('The cache purge feature is not active so we could not purge cache. Make sure you the configuration is correct.') ] );
-            return;
-        }
-
         if (!$url || empty($url)) {
             wp_send_json_error( [ 'message' => sb__('Please specify the URL you would like to purge cache for.') ] );
             return;
@@ -89,36 +99,24 @@ class PurgeActions extends SharedMethods
 
         $cronPurgeIsActive = CachePurge::cronPurgeIsActive();
         try {
-            if (WordPressCachePurge::purgeByUrl($url)) {
-                if ($cronPurgeIsActive) {
-                    wp_send_json_success( [
-                        'title'   => 'Just a moment',
-                        'message' => sprintf(sb__('A cache purge-request for the URL "%s" was added to the queue and will be executed shortly.'), $url),
-                    ] );
-                } else {
-                    wp_send_json_success( [ 'message' => sprintf(sb__('Cache was purged for URL "%s".'), $url) ] );
-                }
+            WordPressCachePurge::purgeByUrl($url);
+            if ($cronPurgeIsActive) {
+                wp_send_json_success([
+                    'title' => 'Just a moment',
+                    'message' => sprintf(sb__('A cache purge-request for the URL "%s" was added to the queue and will be executed shortly.'), $url),
+                ]);
             } else {
-
+                wp_send_json_success(['message' => sprintf(sb__('Cache was purged for URL "%s".'), $url)]);
+            }
+        } catch (ApiError $e) {
+            if ($e->hasMultipleErrors()) {
+                wp_send_json_error($e->getErrors());
+            } else {
+                wp_send_json_error(['message' => $e->getMessage()]);
             }
         } catch (Exception $e) {
-
+            wp_send_json_error(['message' => $e->getMessage()]);
         }
-
-        /*
-        $purgeResult = ;
-
-        if ($purgeResult === false) {
-            wp_send_json_error(); // Unspecified error
-            return;
-        } elseif (is_wp_error($purgeResult)) {
-            $this->handlePurgeItemAlreadyInQueue($purgeResult);
-            return;
-        }
-        */
-
-        // Success
-
     }
 
     /**
@@ -130,36 +128,35 @@ class PurgeActions extends SharedMethods
         sb_ajax_user_allowed();
         $postId = intval( sb_array_get('post_id', $_POST) );
 
-        if (!CachePurge::cachePurgeIsActive()) {
-            wp_send_json_error( [ 'message' => 'The cache purge feature is not active so we could not purge cache. Make sure you the configuration is correct.' ] );
-            return;
-        } elseif (!$postId || empty($postId)) {
-            wp_send_json_error( [ 'message' => 'Please specify the post you would like to purge cache for.' ] );
+        $this->ensureCachePurgeFeatureIsActive();
+
+        if (!$postId || empty($postId)) {
+            wp_send_json_error(['message' => 'Please specify the post you would like to purge cache for.']);
             return;
         } elseif (!sb_post_exists($postId)) {
-            wp_send_json_error( [ 'message' => 'The specified post does not exist.' ] );
+            wp_send_json_error(['message' => 'The specified post does not exist.']);
             return;
         }
 
         $cronPurgeIsActive = CachePurge::cronPurgeIsActive();
-        $purgeResult = WordPressCachePurge::purgeByPost($postId);
-
-        if ($purgeResult === false) {
-            wp_send_json_error(); // Unspecified error
-            return;
-        } elseif (is_wp_error($purgeResult)) {
-            $this->handlePurgeItemAlreadyInQueue($purgeResult);
-            return;
-        }
-
-        // Success
-        if ($cronPurgeIsActive) {
-            wp_send_json_success( [
-                'title'   => 'Just a moment',
-                'message' => sprintf(sb__('A cache purge-request for the post "%s" was added to the queue and will be executed shortly.'), get_the_title($postId)),
-            ] );
-        } else {
-            wp_send_json_success( [ 'message' => sprintf(sb__('Cache was purged for the post post "%s".'), get_the_title($postId) ) ] );
+        try {
+            WordPressCachePurge::purgeByPost($postId);
+            if ($cronPurgeIsActive) {
+                wp_send_json_success( [
+                    'title'   => 'Just a moment',
+                    'message' => sprintf(sb__('A cache purge-request for the post "%s" was added to the queue and will be executed shortly.'), get_the_title($postId)),
+                ] );
+            } else {
+                wp_send_json_success(['message' => sprintf(sb__('Cache was purged for the post post "%s".'), get_the_title($postId))]);
+            }
+        } catch (ApiError $e) {
+            if ($e->hasMultipleErrors()) {
+                wp_send_json_error($e->getErrors());
+            } else {
+                wp_send_json_error(['message' => $e->getMessage()]);
+            }
+        } catch (Exception $e) {
+            wp_send_json_error(['message' => $e->getMessage()]);
         }
     }
 
@@ -261,6 +258,7 @@ class PurgeActions extends SharedMethods
      *
      * @param $purgeResult
      */
+    /*
     private function handlePurgeItemAlreadyInQueue($purgeResult): void
     {
         switch ( $purgeResult->get_error_code() ) {
@@ -282,6 +280,7 @@ class PurgeActions extends SharedMethods
                 wp_send_json_error();
         }
     }
+    */
 
     /**
      * Generate markup for user feedback after purging cache on all sites in multisite-network.

--- a/src/Servebolt/Api/Servebolt/Servebolt.php
+++ b/src/Servebolt/Api/Servebolt/Servebolt.php
@@ -40,7 +40,7 @@ class Servebolt
         $this->setEnvironmentId();
         if ($this->hasApiToken()) {
             $this->client = new ServeboltSdk([
-                'apiToken' => $this->getApiToken()
+                'apiToken' => $this->getApiToken(),
             ]);
         }
     }

--- a/src/Servebolt/CachePurge/Drivers/Cloudflare.php
+++ b/src/Servebolt/CachePurge/Drivers/Cloudflare.php
@@ -5,42 +5,74 @@ namespace Servebolt\Optimizer\CachePurge\Drivers;
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 use Servebolt\Optimizer\Api\Cloudflare\Cloudflare as CloudflareApi;
+use Servebolt\Optimizer\Exceptions\CloudflareApiError;
 use Servebolt\Optimizer\Traits\Singleton;
 use Servebolt\Optimizer\CachePurge\Interfaces\CachePurgeInterface;
+use Servebolt\Optimizer\Sdk\Cloudflare\Exceptions\ApiError as CloudflareSdkApiError;
 
 class Cloudflare implements CachePurgeInterface
 {
     use Singleton;
 
     /**
+     * Purge a URL.
+     *
      * @param string $url
-     * @return mixed
-     * @throws \ReflectionException
+     * @return bool
+     * @throws CloudflareApiError
      */
-    public function purgeByUrl(string $url)
+    public function purgeByUrl(string $url): bool
     {
-        $instance = CloudflareApi::getInstance();
-        return $instance->purgeUrl([$url]);
+        try {
+            $instance = CloudflareApi::getInstance();
+            $instance->purgeUrl([$url]);
+            return true;
+        } catch (CloudflareSdkApiError $e) {
+            $response = $e->getResponse();
+            throw new CloudflareApiError(
+                $response->getErrors(),
+                $response
+            );
+        }
     }
 
     /**
+     * Purge an array of URLs.
+     *
      * @param array $urls
-     * @return mixed
-     * @throws \ReflectionException
+     * @return bool
+     * @throws CloudflareApiError
      */
-    public function purgeByUrls(array $urls)
+    public function purgeByUrls(array $urls): bool
     {
-        $instance = CloudflareApi::getInstance();
-        return $instance->purgeUrl($urls);
+        try {
+            $instance = CloudflareApi::getInstance();
+            $instance->purgeUrl($urls);
+            return true;
+        } catch (CloudflareSdkApiError $e) {
+            throw new CloudflareApiError(
+                $e->getErrors(),
+                $e->getResponse()
+            );
+        }
     }
 
     /**
-     * @return mixed
-     * @throws \ReflectionException
+     * Purge all URL's (in the current zone).
+     * @return bool
+     * @throws CloudflareApiError
      */
-    public function purgeAll()
+    public function purgeAll(): bool
     {
-        $instance = CloudflareApi::getInstance();
-        return $instance->purgeAll();
+        try {
+            $instance = CloudflareApi::getInstance();
+            $instance->purgeAll();
+            return true;
+        } catch (CloudflareSdkApiError $e) {
+            throw new CloudflareApiError(
+                $e->getErrors(),
+                $e->getResponse()
+            );
+        }
     }
 }

--- a/src/Servebolt/CachePurge/Drivers/Cloudflare.php
+++ b/src/Servebolt/CachePurge/Drivers/Cloudflare.php
@@ -25,7 +25,7 @@ class Cloudflare implements CachePurgeInterface
     {
         try {
             $instance = CloudflareApi::getInstance();
-            $instance->purgeUrl([$url]);
+            $instance->purgeUrl($url);
             return true;
         } catch (CloudflareSdkApiError $e) {
             $response = $e->getResponse();
@@ -47,7 +47,7 @@ class Cloudflare implements CachePurgeInterface
     {
         try {
             $instance = CloudflareApi::getInstance();
-            $instance->purgeUrl($urls);
+            $instance->purgeUrls($urls);
             return true;
         } catch (CloudflareSdkApiError $e) {
             throw new CloudflareApiError(

--- a/src/Servebolt/CachePurge/Drivers/Servebolt.php
+++ b/src/Servebolt/CachePurge/Drivers/Servebolt.php
@@ -72,6 +72,12 @@ class Servebolt implements CachePurgeInterface
      */
     public function getPurgeAllPrefixes(): array
     {
+
+        $override = apply_filters('sb_optimizer_acd_purge_all_prefixes_early_override', false); // Let user skip the method and deal with it themselves
+        if (is_array($override)) {
+            return $override;
+        }
+
         $prefixes = [];
         if (is_multisite()) {
             $prefixes = $this->getDomainsWithThirdPartySupport(); // All domains in a multisite-setup

--- a/src/Servebolt/CachePurge/Drivers/Servebolt.php
+++ b/src/Servebolt/CachePurge/Drivers/Servebolt.php
@@ -77,7 +77,7 @@ class Servebolt implements CachePurgeInterface
         $response = $this->apiInstance->environment->purgeCache(
             $this->apiInstance->getEnvironmentId(),
             [],
-            []//$this->getPurgeAllPrefixes()
+            $this->getPurgeAllPrefixes()
         );
         if ($response->wasSuccessful()) {
             return true;

--- a/src/Servebolt/CachePurge/Drivers/Servebolt.php
+++ b/src/Servebolt/CachePurge/Drivers/Servebolt.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 use Servebolt\Optimizer\Api\Servebolt\Servebolt as ServeboltApi;
 use Servebolt\Optimizer\Traits\Singleton;
 use Servebolt\Optimizer\CachePurge\Interfaces\CachePurgeInterface;
+use Exception;
 
 class Servebolt implements CachePurgeInterface
 {
@@ -54,6 +55,8 @@ class Servebolt implements CachePurgeInterface
     }
 
     /**
+     * Purge all cache (for a single site).
+     *
      * @return mixed
      */
     public function purgeAll()
@@ -66,30 +69,75 @@ class Servebolt implements CachePurgeInterface
     }
 
     /**
+     * Purge cache for all sites in multisite-network.
+     *
+     * @return mixed
+     */
+    public function purgeAllNetwork()
+    {
+        return $this->apiInstance->environment->purgeCache(
+            $this->apiInstance->getEnvironmentId(),
+            [],
+            $this->getPurgeAllPrefixesWithMultisiteSupport()
+        );
+    }
+
+    /**
+     * Allow for custom handling of prefixes when purging all cache.
+     *
+     * @param bool $isMultisite
+     * @return array|bool
+     */
+    private function purgeAllPrefixOverride(bool $isMultisite = false)
+    {
+        $override = apply_filters('sb_optimizer_acd_purge_all_prefixes_early_override', [], $isMultisite);
+        if (is_array($override) && !empty($override)) {
+            return $override;
+        }
+        return false;
+    }
+
+    /**
      * Build array of prefix URLs when purging all cache for a site.
      *
      * @return array
      */
     public function getPurgeAllPrefixes(): array
     {
-
-        $override = apply_filters('sb_optimizer_acd_purge_all_prefixes_early_override', false); // Let user skip the method and deal with it themselves
-        if (is_array($override)) {
+        if ($override = $this->purgeAllPrefixOverride(false)) {
             return $override;
         }
-
-        $prefixes = [];
-        if (is_multisite()) {
-            $prefixes = $this->getDomainsWithThirdPartySupport(); // All domains in a multisite-setup
-        } elseif ($domain = $this->extractDomainFromUrl(get_site_url())) {
-            $prefixes = [$domain]; // Single site domain
-        }
-
+        $siteUrl = get_site_url();
+        $siteDomain = $this->extractDomainFromUrl($siteUrl);
+        $prefixes = [$siteDomain];
         if (apply_filters('sb_optimizer_add_www_domains_on_acd_purge_all', true)) {
             $prefixes = $this->addWwwDomains($prefixes);
         }
+        $prefixes = apply_filters('sb_optimizer_acd_purge_all_prefixes', $prefixes);
+        $prefixes = apply_filters('sb_optimizer_acd_purge_all_prefixes_single_site', $prefixes);
+        return $prefixes;
+    }
 
-        return apply_filters('sb_optimizer_acd_purge_all_prefixes', $prefixes);
+    /**
+     * Build array of prefix URLs when purging all cache for a site.
+     *
+     * @return array
+     */
+    public function getPurgeAllPrefixesWithMultisiteSupport(): array
+    {
+        if ($override = $this->purgeAllPrefixOverride(true)) {
+            return $override;
+        }
+        if (!is_multisite()) {
+            return [];
+        }
+        $prefixes = $this->getDomainsWithThirdPartySupport(); // All domains in a multisite-setup
+        if (apply_filters('sb_optimizer_add_www_domains_on_acd_purge_all', true)) {
+            $prefixes = $this->addWwwDomains($prefixes);
+        }
+        $prefixes = apply_filters('sb_optimizer_acd_purge_all_prefixes', $prefixes);
+        $prefixes = apply_filters('sb_optimizer_acd_purge_all_prefixes_multisite', $prefixes);
+        return $prefixes;
     }
 
     /**

--- a/src/Servebolt/CachePurge/Drivers/Servebolt.php
+++ b/src/Servebolt/CachePurge/Drivers/Servebolt.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 use Servebolt\Optimizer\Api\Servebolt\Servebolt as ServeboltApi;
 use Servebolt\Optimizer\Traits\Singleton;
 use Servebolt\Optimizer\CachePurge\Interfaces\CachePurgeInterface;
-use Servebolt\Optimizer\Exceptions\ApiError;
+use Servebolt\Optimizer\Exceptions\ServeboltApiError;
 
 class Servebolt implements CachePurgeInterface
 {
@@ -24,29 +24,6 @@ class Servebolt implements CachePurgeInterface
     }
 
     /**
-     * @param string $url
-     * @return bool
-     */
-    public function purgeByUrl(string $url): bool
-    {
-        $response = $this->apiInstance->environment()->purgeCache([$url]);
-        return $response->wasSuccessful();
-    }
-
-    /**
-     * @param array $urls
-     * @return bool
-     */
-    public function purgeByUrls(array $urls): bool
-    {
-        $response = $this->apiInstance->environment->purgeCache(
-            $this->apiInstance->getEnvironmentId(),
-            $urls
-        );
-        return $response->wasSuccessful();
-    }
-
-    /**
      * Check whether the Servebolt SDK is configured correctly.
      *
      * @return bool
@@ -57,11 +34,45 @@ class Servebolt implements CachePurgeInterface
     }
 
     /**
+     * @param string $url
+     * @return bool
+     * @throws ServeboltApiError
+     */
+    public function purgeByUrl(string $url): bool
+    {
+        $response = $this->apiInstance->environment()->purgeCache([$url]);
+        if ($response->wasSuccessful()) {
+            return true;
+        } else {
+            throw new ServeboltApiError($response->getErrors(), $response);
+        }
+    }
+
+    /**
+     * @param array $urls
+     * @return bool
+     * @throws ServeboltApiError
+     */
+    public function purgeByUrls(array $urls): bool
+    {
+        $response = $this->apiInstance->environment->purgeCache(
+            $this->apiInstance->getEnvironmentId(),
+            $urls
+        );
+        if ($response->wasSuccessful()) {
+            return true;
+        } else {
+            throw new ServeboltApiError($response->getErrors(), $response);
+        }
+    }
+
+    /**
      * Purge all cache (for a single site).
      *
-     * @return mixed
+     * @return bool
+     * @throws ServeboltApiError
      */
-    public function purgeAll()
+    public function purgeAll(): bool
     {
         $response = $this->apiInstance->environment->purgeCache(
             $this->apiInstance->getEnvironmentId(),
@@ -71,23 +82,28 @@ class Servebolt implements CachePurgeInterface
         if ($response->wasSuccessful()) {
             return true;
         } else {
-           throw new ApiError($response->getErrors(), $response);
+           throw new ServeboltApiError($response->getErrors(), $response);
         }
     }
 
     /**
      * Purge cache for all sites in multisite-network.
      *
-     * @return mixed
+     * @return bool
+     * @throws ServeboltApiError
      */
-    public function purgeAllNetwork()
+    public function purgeAllNetwork(): bool
     {
         $response = $this->apiInstance->environment->purgeCache(
             $this->apiInstance->getEnvironmentId(),
             [],
             $this->getPurgeAllPrefixesWithMultisiteSupport()
         );
-        return $response->wasSuccessful();
+        if ($response->wasSuccessful()) {
+            return true;
+        } else {
+            throw new ServeboltApiError($response->getErrors(), $response);
+        }
     }
 
     /**

--- a/src/Servebolt/CachePurge/Drivers/Servebolt.php
+++ b/src/Servebolt/CachePurge/Drivers/Servebolt.php
@@ -77,7 +77,7 @@ class Servebolt implements CachePurgeInterface
         $response = $this->apiInstance->environment->purgeCache(
             $this->apiInstance->getEnvironmentId(),
             [],
-            $this->getPurgeAllPrefixes()
+            []//$this->getPurgeAllPrefixes()
         );
         if ($response->wasSuccessful()) {
             return true;

--- a/src/Servebolt/CachePurge/Drivers/Servebolt.php
+++ b/src/Servebolt/CachePurge/Drivers/Servebolt.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 use Servebolt\Optimizer\Api\Servebolt\Servebolt as ServeboltApi;
 use Servebolt\Optimizer\Traits\Singleton;
 use Servebolt\Optimizer\CachePurge\Interfaces\CachePurgeInterface;
-use Exception;
+use Servebolt\Optimizer\Exceptions\ApiError;
 
 class Servebolt implements CachePurgeInterface
 {
@@ -25,23 +25,25 @@ class Servebolt implements CachePurgeInterface
 
     /**
      * @param string $url
-     * @return mixed
+     * @return bool
      */
-    public function purgeByUrl(string $url)
+    public function purgeByUrl(string $url): bool
     {
-        return $this->apiInstance->environment()->purgeCache([$url]);
+        $response = $this->apiInstance->environment()->purgeCache([$url]);
+        return $response->wasSuccessful();
     }
 
     /**
      * @param array $urls
-     * @return mixed
+     * @return bool
      */
-    public function purgeByUrls(array $urls)
+    public function purgeByUrls(array $urls): bool
     {
-        return $this->apiInstance->environment->purgeCache(
+        $response = $this->apiInstance->environment->purgeCache(
             $this->apiInstance->getEnvironmentId(),
             $urls
         );
+        return $response->wasSuccessful();
     }
 
     /**
@@ -61,11 +63,16 @@ class Servebolt implements CachePurgeInterface
      */
     public function purgeAll()
     {
-        return $this->apiInstance->environment->purgeCache(
+        $response = $this->apiInstance->environment->purgeCache(
             $this->apiInstance->getEnvironmentId(),
             [],
             $this->getPurgeAllPrefixes()
         );
+        if ($response->wasSuccessful()) {
+            return true;
+        } else {
+           throw new ApiError($response->getErrors(), $response);
+        }
     }
 
     /**
@@ -75,11 +82,12 @@ class Servebolt implements CachePurgeInterface
      */
     public function purgeAllNetwork()
     {
-        return $this->apiInstance->environment->purgeCache(
+        $response = $this->apiInstance->environment->purgeCache(
             $this->apiInstance->getEnvironmentId(),
             [],
             $this->getPurgeAllPrefixesWithMultisiteSupport()
         );
+        return $response->wasSuccessful();
     }
 
     /**

--- a/src/Servebolt/CachePurge/ThirdPartyFunctions.php
+++ b/src/Servebolt/CachePurge/ThirdPartyFunctions.php
@@ -1,18 +1,27 @@
 <?php
 
-use Servebolt\Optimizer\CachePurge\CachePurge as CachePurgeDriver;
+use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
+
+/**
+ * Purge cache for URL.
+ *
+ * @param string $url
+ * @return bool
+ */
+function sb_purge_url(string $url): bool
+{
+    return WordPressCachePurge::purgeByUrl($url);
+}
 
 /**
  * Purge cache for post.
  *
  * @param $post_id
  * @return bool
- * @throws ReflectionException
  */
 function sb_purge_post_cache($post_id) : bool
 {
-    $driver = CachePurgeDriver::getInstance();
-    return $driver->purgeCacheForPost($post_id);
+    return WordPressCachePurge::purgeByPostId((int) $post_id);
 }
 
 /**
@@ -20,27 +29,18 @@ function sb_purge_post_cache($post_id) : bool
  *
  * @param $term_id
  * @return bool
- * @throws ReflectionException
  */
 function sb_purge_post_term($term_id) : bool
 {
-    $driver = CachePurgeDriver::getInstance();
-    return $driver->purgeCacheForTerm($term_id);
+    return WordPressCachePurge::purgeByTermId((int) $term_id);
 }
 
 /**
  * Purge all cache.
  *
- * NOTE: Only available when using Cloudflare cache purging.
- *
  * @return bool
- * @throws ReflectionException
  */
 function sb_purge_all() : bool
 {
-    $driver = CachePurgeDriver::getInstance();
-    if (method_exists($driver, 'purgeAll')) {
-        return $driver->purgeAll();
-    }
-    return false;
+    return WordPressCachePurge::purgeAll();
 }

--- a/src/Servebolt/CachePurge/ThirdPartyFunctions.php
+++ b/src/Servebolt/CachePurge/ThirdPartyFunctions.php
@@ -1,46 +1,168 @@
 <?php
 
 use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
+use Servebolt\Optimizer\Exceptions\ApiError;
 
 /**
  * Purge cache for URL.
  *
  * @param string $url
- * @return bool
+ * @param bool $return_wp_error_object
+ * @return bool|WP_Error
  */
-function sb_purge_url(string $url): bool
+function sb_purge_url(string $url, bool $return_wp_error_object = false)
 {
-    return WordPressCachePurge::purgeByUrl($url);
+    try {
+        return WordPressCachePurge::purgeByUrl($url);
+    } catch (ApiError $e) {
+        // TODO: Handle API error message
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    } catch (Exception $e) {
+        // TODO: Handle general error
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    }
 }
 
 /**
  * Purge cache for post.
  *
  * @param $post_id
- * @return bool
+ * @param bool $return_wp_error_object
+ * @return bool|WP_Error
  */
-function sb_purge_post_cache($post_id) : bool
+function sb_purge_post_cache($post_id, bool $return_wp_error_object = false)
 {
-    return WordPressCachePurge::purgeByPostId((int) $post_id);
+    try {
+        return WordPressCachePurge::purgeByPostId(
+            (int) $post_id
+        );
+    } catch (ApiError $e) {
+        // TODO: Handle API error message
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    } catch (Exception $e) {
+        // TODO: Handle general error
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    }
+    return false;
 }
 
 /**
  * Purge cache for term.
  *
  * @param $term_id
- * @return bool
+ * @param $taxonomy_slug
+ * @param bool $return_wp_error_object
+ * @return bool|WP_Error
  */
-function sb_purge_post_term($term_id) : bool
+function sb_purge_term_cache($term_id, $taxonomy_slug, bool $return_wp_error_object = false)
 {
-    return WordPressCachePurge::purgeByTermId((int) $term_id);
+    try {
+        return WordPressCachePurge::purgeByTermId(
+            (int) $term_id
+        );
+    } catch (ApiError $e) {
+        // TODO: Handle API error message
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    } catch (Exception $e) {
+        // TODO: Handle general error
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    }
+    return false;
 }
 
 /**
  * Purge all cache.
  *
- * @return bool
+ * @param bool $return_wp_error_object
+ * @return bool|WP_Error
  */
-function sb_purge_all() : bool
+function sb_purge_all(bool $return_wp_error_object = false)
 {
-    return WordPressCachePurge::purgeAll();
+    try {
+        return WordPressCachePurge::purgeAll();
+    } catch (ApiError $e) {
+        // TODO: Handle API error message
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    } catch (Exception $e) {
+        // TODO: Handle general error
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    }
+}
+
+/**
+ * Purge all cache by blog Id (multisite only).
+ *
+ * @param $blog_id
+ * @param bool $return_wp_error_object
+ * @return false|WP_Error
+ */
+function sb_purge_all_by_blog_id($blog_id, bool $return_wp_error_object = false)
+{
+    try {
+        return WordPressCachePurge::purgeAllByBlogId(
+            (int) $blog_id
+        );
+    } catch (ApiError $e) {
+        // TODO: Handle API error message
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    } catch (Exception $e) {
+        // TODO: Handle general error
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    }
+}
+
+/**
+ * Purge all cache in network (multisite only).
+ *
+ * @param bool $return_wp_error_object
+ * @return bool|WP_Error
+ */
+function sb_purge_all_network(bool $return_wp_error_object = false)
+{
+    try {
+        return WordPressCachePurge::purgeAllNetwork();
+    } catch (ApiError $e) {
+        // TODO: Handle API error message
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    } catch (Exception $e) {
+        // TODO: Handle general error
+        if ($return_wp_error_object) {
+            // TODO: Return WP Error object
+        }
+        return false;
+    }
+
 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
@@ -2,8 +2,12 @@
 
 namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
 
-use WP_Error;
+use Servebolt\Optimizer\CachePurge\CachePurge as CachePurgeDriver;
 
+/**
+ * Trait PostMethods
+ * @package Servebolt\Optimizer\CachePurge\WordPressCachePurge
+ */
 trait PostMethods
 {
 
@@ -25,10 +29,9 @@ trait PostMethods
      * Purge post cache by post Id.
      *
      * @param int $postId
-     * @param bool $returnWpError
      * @return bool|WP_Error
      */
-    public static function purgePostCache(int $postId, bool $returnWpError = false): bool
+    public static function purgePostCache(int $postId): bool
     {
 
         // If this is just a revision, don't purge anything.
@@ -38,7 +41,7 @@ trait PostMethods
 
         // TODO: Add queue handling here
         $urlsToPurge = self::getUrlsToPurgeByPostId($postId);
-        $cachePurgeDriver = CachePurge::getInstance();
+        $cachePurgeDriver = CachePurgeDriver::getInstance();
         return $cachePurgeDriver->purgeByUrls($urlsToPurge);
     }
 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
@@ -36,24 +36,9 @@ trait PostMethods
             return false;
         }
 
-        try {
-            // TODO: Add queue handling here
-            $urlsToPurge = self::getUrlsToPurgeByPostId($postId);
-            $cachePurgeDriver = CachePurge::getInstance();
-            return $cachePurgeDriver->purgeByUrls($urlsToPurge);
-        } catch (ApiError $e) {
-            // TODO: Handle API error message
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        } catch (Exception $e) {
-            // TODO: Handle general error
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        }
-        return false;
+        // TODO: Add queue handling here
+        $urlsToPurge = self::getUrlsToPurgeByPostId($postId);
+        $cachePurgeDriver = CachePurge::getInstance();
+        return $cachePurgeDriver->purgeByUrls($urlsToPurge);
     }
 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
@@ -2,6 +2,8 @@
 
 namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
 
+use WP_Error;
+
 trait PostMethods
 {
 
@@ -23,9 +25,10 @@ trait PostMethods
      * Purge post cache by post Id.
      *
      * @param int $postId
-     * @return bool
+     * @param bool $returnWpError
+     * @return bool|WP_Error
      */
-    public static function purgePostCache(int $postId): bool
+    public static function purgePostCache(int $postId, bool $returnWpError = false): bool
     {
 
         // If this is just a revision, don't purge anything.
@@ -33,10 +36,24 @@ trait PostMethods
             return false;
         }
 
-        // TODO: Add queue handling here
-
-        $urlsToPurge = self::getUrlsToPurgeByPostId($postId);
-        $cachePurgeDriver = CachePurge::getInstance();
-        return $cachePurgeDriver->purgeByUrls($urlsToPurge);
+        try {
+            // TODO: Add queue handling here
+            $urlsToPurge = self::getUrlsToPurgeByPostId($postId);
+            $cachePurgeDriver = CachePurge::getInstance();
+            return $cachePurgeDriver->purgeByUrls($urlsToPurge);
+        } catch (ApiError $e) {
+            // TODO: Handle API error message
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        } catch (Exception $e) {
+            // TODO: Handle general error
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        }
+        return false;
     }
 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
+
+trait PostMethods
+{
+
+    /**
+     * Get all the URLs to purge for a given post.
+     *
+     * @param int $postId
+     * @return array
+     */
+    private static function getUrlsToPurgeByPostId(int $postId): array
+    {
+        return sb_cf_cache_purge_object(
+            $postId,
+            'post'
+        )->get_urls();
+    }
+
+    /**
+     * Purge post cache by post Id.
+     *
+     * @param int $postId
+     * @return bool
+     */
+    public static function purgePostCache(int $postId): bool
+    {
+
+        // If this is just a revision, don't purge anything.
+        if ( ! $postId || wp_is_post_revision( $postId ) ) {
+            return false;
+        }
+
+        // TODO: Add queue handling here
+
+        $urlsToPurge = self::getUrlsToPurgeByPostId($postId);
+        $cachePurgeDriver = CachePurge::getInstance();
+        return $cachePurgeDriver->purgeByUrls($urlsToPurge);
+    }
+}

--- a/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
@@ -2,8 +2,12 @@
 
 namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
 
-use WP_Error;
+use Servebolt\Optimizer\CachePurge\CachePurge as CachePurgeDriver;
 
+/**
+ * Trait TermMethods
+ * @package Servebolt\Optimizer\CachePurge\WordPressCachePurge
+ */
 trait TermMethods
 {
 
@@ -28,14 +32,13 @@ trait TermMethods
      *
      * @param int $termId
      * @param string $taxonomySlug
-     * @param bool $returnWpError
      * @return bool
      */
-    public static function purgeTermCache(int $termId, string $taxonomySlug, bool $returnWpError = false): bool
+    public static function purgeTermCache(int $termId, string $taxonomySlug): bool
     {
         // TODO: Add queue handling here
         $urlsToPurge = self::getUrlsToPurgeByTermId($termId, $taxonomySlug);
-        $cachePurgeDriver = CachePurge::getInstance();
+        $cachePurgeDriver = CachePurgeDriver::getInstance();
         return $cachePurgeDriver->purgeByUrls($urlsToPurge);
     }
 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
@@ -2,6 +2,8 @@
 
 namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
 
+use WP_Error;
+
 trait TermMethods
 {
 
@@ -25,14 +27,30 @@ trait TermMethods
      * Purge cache for term.
      *
      * @param int $termId
-     * @param string $taxonomy
+     * @param string $taxonomySlug
+     * @param bool $returnWpError
      * @return bool
      */
-    public static function purgeTermCache(int $termId, string $taxonomy): bool
+    public static function purgeTermCache(int $termId, string $taxonomySlug, bool $returnWpError = false): bool
     {
-        // TODO: Add queue handling here
-        $urlsToPurge = self::getUrlsToPurgeByTermId($termId, $taxonomy);
-        $cachePurgeDriver = CachePurge::getInstance();
-        return $cachePurgeDriver->purgeByUrls($urlsToPurge);
+        try {
+            // TODO: Add queue handling here
+            $urlsToPurge = self::getUrlsToPurgeByTermId($termId, $taxonomySlug);
+            $cachePurgeDriver = CachePurge::getInstance();
+            return $cachePurgeDriver->purgeByUrls($urlsToPurge);
+        } catch (ApiError $e) {
+            // TODO: Handle API error message
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        } catch (Exception $e) {
+            // TODO: Handle general error
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        }
+        return false;
     }
 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
+
+trait TermMethods
+{
+
+    /**
+     * Get all the URLs to purge for a given term.
+     *
+     * @param int $termId
+     * @param string $taxonomySlug
+     * @return bool|mixed
+     */
+    private function getUrlsToPurgeByTermId(int $termId, string $taxonomySlug): array
+    {
+        return sb_cf_cache_purge_object(
+            $termId,
+            'term',
+            ['taxonomy_slug' => $taxonomySlug]
+        )->get_urls();
+    }
+
+    /**
+     * Purge cache for term.
+     *
+     * @param int $termId
+     * @param string $taxonomy
+     * @return bool
+     */
+    public static function purgeTermCache(int $termId, string $taxonomy): bool
+    {
+        // TODO: Add queue handling here
+        $urlsToPurge = self::getUrlsToPurgeByTermId($termId, $taxonomy);
+        $cachePurgeDriver = CachePurge::getInstance();
+        return $cachePurgeDriver->purgeByUrls($urlsToPurge);
+    }
+}

--- a/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
@@ -33,24 +33,9 @@ trait TermMethods
      */
     public static function purgeTermCache(int $termId, string $taxonomySlug, bool $returnWpError = false): bool
     {
-        try {
-            // TODO: Add queue handling here
-            $urlsToPurge = self::getUrlsToPurgeByTermId($termId, $taxonomySlug);
-            $cachePurgeDriver = CachePurge::getInstance();
-            return $cachePurgeDriver->purgeByUrls($urlsToPurge);
-        } catch (ApiError $e) {
-            // TODO: Handle API error message
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        } catch (Exception $e) {
-            // TODO: Handle general error
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        }
-        return false;
+        // TODO: Add queue handling here
+        $urlsToPurge = self::getUrlsToPurgeByTermId($termId, $taxonomySlug);
+        $cachePurgeDriver = CachePurge::getInstance();
+        return $cachePurgeDriver->purgeByUrls($urlsToPurge);
     }
 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
@@ -2,10 +2,7 @@
 
 namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
 
-use WP_Error;
-use Exception;
-use Servebolt\Optimizer\CachePurge\CachePurge;
-use Servebolt\Optimizer\Exceptions\ApiError;
+use Servebolt\Optimizer\CachePurge\CachePurge as CachePurgeDriver;
 
 /**
  * Class WordPressCachePurge
@@ -24,30 +21,16 @@ class WordPressCachePurge
      *
      * @param string $url
      * @param bool $returnWpError
-     * @return bool|WP_Error
+     * @return bool
      */
     public static function purgeByUrl(string $url, bool $returnWpError = false)
     {
         if ($postId = url_to_postid($url)) {
             return self::purgePostCache($postId);
         } else {
-            try {
-                // TODO: Add queue handling here
-                $cachePurgeDriver = CachePurge::getInstance();
-                return $cachePurgeDriver->purgeByUrl($url);
-            } catch (ApiError $e) {
-                // TODO: Handle API error message
-                if ($returnWpError) {
-                    // TODO: Return WP Error object
-                }
-                return false;
-            } catch (Exception $e) {
-                // TODO: Handle general error
-                if ($returnWpError) {
-                    // TODO: Return WP Error object
-                }
-                return false;
-            }
+            // TODO: Add queue handling here
+            $cachePurgeDriver = CachePurgeDriver::getInstance();
+            return $cachePurgeDriver->purgeByUrl($url);
         }
     }
 
@@ -57,7 +40,7 @@ class WordPressCachePurge
      * @param int $termId
      * @param string $taxonomySlug
      * @param bool $returnWpError
-     * @return bool|WP_Error
+     * @return bool
      */
     public function purgeByTermId(int $termId, string $taxonomySlug, bool $returnWpError = false)
     {
@@ -69,7 +52,7 @@ class WordPressCachePurge
      *
      * @param int $postId
      * @param bool $returnWpError
-     * @return bool|WP_Error
+     * @return bool
      */
     public static function purgeByPostId(int $postId, bool $returnWpError = false)
     {
@@ -80,27 +63,13 @@ class WordPressCachePurge
      * Purge all cache on the site.
      *
      * @param bool $returnWpError
-     * @return bool|WP_Error
+     * @return bool
      */
     public static function purgeAll(bool $returnWpError = false)
     {
         // TODO: Add queue handling here
-        try {
-            $cachePurgeDriver = CachePurge::getInstance();
-            return $cachePurgeDriver->purgeAll();
-        } catch (ApiError $e) {
-            // TODO: Handle API error message
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        } catch (Exception $e) {
-            // TODO: Handle general error
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        }
+        $cachePurgeDriver = CachePurgeDriver::getInstance();
+        return $cachePurgeDriver->purgeAll();
     }
 
     /**
@@ -108,7 +77,7 @@ class WordPressCachePurge
      *
      * @param int $blogId
      * @param bool $returnWpError
-     * @return false|WP_Error
+     * @return bool
      */
     public static function purgeAllByBlogId(int $blogId, bool $returnWpError = false)
     {
@@ -117,29 +86,16 @@ class WordPressCachePurge
         }
         // TODO: Add switch to blog-logic here
         // TODO: Add queue handling here
-        try {
-            $cachePurgeDriver = CachePurge::getInstance();
-            return $cachePurgeDriver->purgeAll();
-        } catch (ApiError $e) {
-            // TODO: Handle API error message
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        } catch (Exception $e) {
-            // TODO: Handle general error
-            if ($returnWpError) {
-                // TODO: Return WP Error object
-            }
-            return false;
-        }
+        $cachePurgeDriver = CachePurgeDriver::getInstance();
+        return $cachePurgeDriver->purgeAll();
+
     }
 
     /**
      * Purge all cache in network (only for multisites).
      *
      * @param bool $returnWpError
-     * @return bool|WP_Error
+     * @return bool
      */
     public function purgeAllNetwork(bool $returnWpError = false)
     {

--- a/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
+
+use Servebolt\Optimizer\CachePurge\CachePurge;
+
+/**
+ * Class WordPressCachePurge
+ * @package Servebolt\Optimizer\CachePurge
+ */
+class WordPressCachePurge
+{
+
+    use PostMethods, TermMethods;
+
+    /**
+     * Purge cache by URL.
+     *
+     * @param string $url
+     * @return bool
+     */
+    public static function purgeByUrl(string $url): bool
+    {
+        if ($postId = url_to_postid($url)) {
+            return self::purgePostCache($postId);
+        } else {
+            // TODO: Add queue handling here
+            $cachePurgeDriver = CachePurge::getInstance();
+            return $cachePurgeDriver->purgeByUrl($url);
+        }
+    }
+
+    /**
+     * Alias for method "purgeTermCache".
+     *
+     * @param int $termId
+     * @return bool
+     */
+    public function purgeByTermId(int $termId): bool
+    {
+        return self::purgeTermCache($termId);
+    }
+
+    /**
+     * Alias for method "purgePostCache".
+     *
+     * @param int $postId
+     * @return bool
+     */
+    public static function purgeByPostId(int $postId): bool
+    {
+        return self::purgePostCache($postId);
+    }
+
+    /**
+     * Purge all cache on the site.
+     *
+     * @return bool
+     */
+    public function purgeAll(): bool
+    {
+        // TODO: Add queue handling here
+        $cachePurgeDriver = CachePurge::getInstance();
+        return $cachePurgeDriver->purgeAll();
+    }
+
+    /**
+     * Purge all cache in network (only for multisites).
+     *
+     * @return bool
+     */
+    public function purgeAllNetwork(): bool
+    {
+        if (!is_multisite()) {
+            return false;
+        }
+        // TODO: Add support for purge all in multisite context
+        // TODO: Add queue handling here
+    }
+
+}

--- a/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
@@ -2,10 +2,16 @@
 
 namespace Servebolt\Optimizer\CachePurge\WordPressCachePurge;
 
+use WP_Error;
+use Exception;
 use Servebolt\Optimizer\CachePurge\CachePurge;
+use Servebolt\Optimizer\Exceptions\ApiError;
 
 /**
  * Class WordPressCachePurge
+ *
+ * This class acts as a layer between the post/term to be purged and the cache purge driver.
+ *
  * @package Servebolt\Optimizer\CachePurge
  */
 class WordPressCachePurge
@@ -17,16 +23,31 @@ class WordPressCachePurge
      * Purge cache by URL.
      *
      * @param string $url
-     * @return bool
+     * @param bool $returnWpError
+     * @return bool|WP_Error
      */
-    public static function purgeByUrl(string $url): bool
+    public static function purgeByUrl(string $url, bool $returnWpError = false)
     {
         if ($postId = url_to_postid($url)) {
             return self::purgePostCache($postId);
         } else {
-            // TODO: Add queue handling here
-            $cachePurgeDriver = CachePurge::getInstance();
-            return $cachePurgeDriver->purgeByUrl($url);
+            try {
+                // TODO: Add queue handling here
+                $cachePurgeDriver = CachePurge::getInstance();
+                return $cachePurgeDriver->purgeByUrl($url);
+            } catch (ApiError $e) {
+                // TODO: Handle API error message
+                if ($returnWpError) {
+                    // TODO: Return WP Error object
+                }
+                return false;
+            } catch (Exception $e) {
+                // TODO: Handle general error
+                if ($returnWpError) {
+                    // TODO: Return WP Error object
+                }
+                return false;
+            }
         }
     }
 
@@ -34,46 +55,98 @@ class WordPressCachePurge
      * Alias for method "purgeTermCache".
      *
      * @param int $termId
-     * @return bool
+     * @param string $taxonomySlug
+     * @param bool $returnWpError
+     * @return bool|WP_Error
      */
-    public function purgeByTermId(int $termId): bool
+    public function purgeByTermId(int $termId, string $taxonomySlug, bool $returnWpError = false)
     {
-        return self::purgeTermCache($termId);
+        return self::purgeTermCache($termId, $taxonomySlug, $returnWpError);
     }
 
     /**
      * Alias for method "purgePostCache".
      *
      * @param int $postId
-     * @return bool
+     * @param bool $returnWpError
+     * @return bool|WP_Error
      */
-    public static function purgeByPostId(int $postId): bool
+    public static function purgeByPostId(int $postId, bool $returnWpError = false)
     {
-        return self::purgePostCache($postId);
+        return self::purgePostCache($postId, $returnWpError);
     }
 
     /**
      * Purge all cache on the site.
      *
-     * @return bool
+     * @param bool $returnWpError
+     * @return bool|WP_Error
      */
-    public function purgeAll(): bool
+    public static function purgeAll(bool $returnWpError = false)
     {
         // TODO: Add queue handling here
-        $cachePurgeDriver = CachePurge::getInstance();
-        return $cachePurgeDriver->purgeAll();
+        try {
+            $cachePurgeDriver = CachePurge::getInstance();
+            return $cachePurgeDriver->purgeAll();
+        } catch (ApiError $e) {
+            // TODO: Handle API error message
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        } catch (Exception $e) {
+            // TODO: Handle general error
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Purge all cache for given site (only for multisites).
+     *
+     * @param int $blogId
+     * @param bool $returnWpError
+     * @return false|WP_Error
+     */
+    public static function purgeAllByBlogId(int $blogId, bool $returnWpError = false)
+    {
+        if (!is_multisite()) {
+            return false;
+        }
+        // TODO: Add switch to blog-logic here
+        // TODO: Add queue handling here
+        try {
+            $cachePurgeDriver = CachePurge::getInstance();
+            return $cachePurgeDriver->purgeAll();
+        } catch (ApiError $e) {
+            // TODO: Handle API error message
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        } catch (Exception $e) {
+            // TODO: Handle general error
+            if ($returnWpError) {
+                // TODO: Return WP Error object
+            }
+            return false;
+        }
     }
 
     /**
      * Purge all cache in network (only for multisites).
      *
-     * @return bool
+     * @param bool $returnWpError
+     * @return bool|WP_Error
      */
-    public function purgeAllNetwork(): bool
+    public function purgeAllNetwork(bool $returnWpError = false)
     {
         if (!is_multisite()) {
             return false;
         }
+        // TODO: Return Return WP Error object if $returnWpError is true
         // TODO: Add support for purge all in multisite context
         // TODO: Add queue handling here
     }

--- a/src/Servebolt/Exceptions/ApiError.php
+++ b/src/Servebolt/Exceptions/ApiError.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions;
+
+use Exception;
+use Throwable;
+
+/**
+ * Class ApiError
+ * @package Servebolt\Optimizer\Exceptions
+ */
+class ApiError extends Exception
+{
+
+    /**
+     * ApiError constructor.
+     * @param array $errors
+     * @param $response
+     * @param Throwable|null $previous
+     */
+    public function __construct(array $errors, $response, Throwable $previous = null)
+    {
+        $this->errors = $errors;
+        $this->response = $response;
+        parent::__construct('', '', $previous);
+    }
+
+    /**
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Servebolt/Exceptions/ApiError.php
+++ b/src/Servebolt/Exceptions/ApiError.php
@@ -3,6 +3,8 @@
 namespace Servebolt\Optimizer\Exceptions;
 
 use Exception;
+use Servebolt\Optimizer\Exceptions\ErrorTranslator\ServeboltErrorTranslation;
+use Servebolt\Optimizer\Exceptions\ErrorTranslator\CloudflareErrorTranslation;
 
 /**
  * Class ApiError
@@ -40,10 +42,30 @@ abstract class ApiError extends Exception
      */
     public function __construct(array $errors, string $driver, $response)
     {
-        $this->errors = $errors;
+        $this->errors = $this->translateErrors($errors, $driver);
         $this->driver = $driver;
         $this->response = $response;
         $this->initializeParent();
+    }
+
+    /**
+     * Translate API-errors to something that gives more sense to the end user.
+     *
+     * @param array $errors
+     * @param string $driver
+     * @return array
+     */
+    public function translateErrors(array $errors, string $driver): array
+    {
+        switch ($driver) {
+            case 'acd':
+                $i = new ServeboltErrorTranslation($errors);
+                return $i->translate();
+            case 'cloudflare':
+                $i = new CloudflareErrorTranslation($errors);
+                return $i->translate();
+        }
+        return $errors;
     }
 
     private function initializeParent(): void

--- a/src/Servebolt/Exceptions/ApiError.php
+++ b/src/Servebolt/Exceptions/ApiError.php
@@ -3,29 +3,81 @@
 namespace Servebolt\Optimizer\Exceptions;
 
 use Exception;
-use Throwable;
 
 /**
  * Class ApiError
  * @package Servebolt\Optimizer\Exceptions
  */
-class ApiError extends Exception
+abstract class ApiError extends Exception
 {
+
+    /**
+     * An array of error(s).
+     *
+     * @var array
+     */
+    protected $errors;
+
+    /**
+     * The driver type that the API error originated from.
+     *
+     * @var string
+     */
+    protected $driver;
+
+    /**
+     * The response object for the driver.
+     *
+     * @var mixed
+     */
+    protected $response;
 
     /**
      * ApiError constructor.
      * @param array $errors
-     * @param $response
-     * @param Throwable|null $previous
+     * @param string $driver
+     * @param mixed $response
      */
-    public function __construct(array $errors, $response, Throwable $previous = null)
+    public function __construct(array $errors, string $driver, $response)
     {
         $this->errors = $errors;
+        $this->driver = $driver;
         $this->response = $response;
-        parent::__construct('', '', $previous);
+        $this->initializeParent();
+    }
+
+    private function initializeParent(): void
+    {
+        if ($this->hasErrors()) {
+            $errors = $this->getErrors();
+            $error = current($errors);
+            parent::__construct($error->message, $error->code);
+        }
     }
 
     /**
+     * Whether we have multiple error messages.
+     *
+     * @return bool
+     */
+    public function hasMultipleErrors(): bool
+    {
+        return $this->hasErrors() && count($this->getErrors()) > 1;
+    }
+
+    /**
+     * Whether we have error message(s).
+     *
+     * @return bool
+     */
+    public function hasErrors(): bool
+    {
+        return !empty($this->getErrors());
+    }
+
+    /**
+     * Get errors.
+     *
      * @return array
      */
     public function getErrors(): array
@@ -34,6 +86,18 @@ class ApiError extends Exception
     }
 
     /**
+     * Get the driver where the API originated from.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return $this->driver;
+    }
+
+    /**
+     * Get the response that communicated the error(s).
+     *
      * @return mixed
      */
     public function getResponse()

--- a/src/Servebolt/Exceptions/ApiMessage.php
+++ b/src/Servebolt/Exceptions/ApiMessage.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions;
+
+use Exception;
+use Servebolt\Optimizer\Exceptions\MessageTranslator\ServeboltMessageTranslation;
+use Servebolt\Optimizer\Exceptions\MessageTranslator\CloudflareMessageTranslation;
+
+/**
+ * Class ApiMessage
+ * @package Servebolt\Optimizer\Exceptions
+ */
+abstract class ApiMessage extends Exception
+{
+
+    /**
+     * An array of message(s).
+     *
+     * @var array
+     */
+    protected $messages;
+
+    /**
+     * The driver type that the API message originated from.
+     *
+     * @var string
+     */
+    protected $driver;
+
+    /**
+     * The response object for the driver.
+     *
+     * @var mixed
+     */
+    protected $response;
+
+    /**
+     * ApiMessage constructor.
+     * @param array $messages
+     * @param string $driver
+     * @param mixed $response
+     */
+    public function __construct(array $messages, string $driver, $response)
+    {
+        $this->messages = $this->translateMessages($messages, $driver);
+        $this->driver = $driver;
+        $this->response = $response;
+        $this->initializeParent();
+    }
+
+    /**
+     * Translate API-messages to something that gives more sense to the end user.
+     *
+     * @param array $messages
+     * @param string $driver
+     * @return array
+     */
+    public function translateMessages(array $messages, string $driver): array
+    {
+        switch ($driver) {
+            case 'acd':
+                $i = new ServeboltMessageTranslation($messages);
+                return $i->translate();
+            case 'cloudflare':
+                $i = new CloudflareMessageTranslation($messages);
+                return $i->translate();
+        }
+        return $messages;
+    }
+
+    private function initializeParent(): void
+    {
+        if ($this->hasMessages()) {
+            $messages = $this->getMessages();
+            $message = current($messages);
+            parent::__construct($message->message, $message->code);
+        }
+    }
+
+    /**
+     * Whether we have multiple messages.
+     *
+     * @return bool
+     */
+    public function hasMultipleMessages(): bool
+    {
+        return $this->hasMessages() && count($this->getMessages()) > 1;
+    }
+
+    /**
+     * Whether we have message(s).
+     *
+     * @return bool
+     */
+    public function hasMessages(): bool
+    {
+        return !empty($this->getMessages());
+    }
+
+    /**
+     * Get messages.
+     *
+     * @return array
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+
+    /**
+     * Get the driver where the API originated from.
+     *
+     * @return string
+     */
+    public function getDriver(): string
+    {
+        return $this->driver;
+    }
+
+    /**
+     * Get the response that communicated the message(s).
+     *
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Servebolt/Exceptions/CloudflareApiError.php
+++ b/src/Servebolt/Exceptions/CloudflareApiError.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions;
+
+/**
+ * Class CloudflareApiError
+ * @package Servebolt\Optimizer\Exceptions
+ */
+class CloudflareApiError extends ApiError
+{
+
+    /**
+     * ApiError constructor.
+     * @param array $errors
+     * @param mixed $response
+     */
+    public function __construct(array $errors, $response)
+    {
+        parent::__construct($errors, 'cloudflare', $response);
+    }
+}

--- a/src/Servebolt/Exceptions/ErrorTranslator/CloudflareErrorTranslation.php
+++ b/src/Servebolt/Exceptions/ErrorTranslator/CloudflareErrorTranslation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions\ErrorTranslator;
+
+/**
+ * Class CloudflareErrorTranslation
+ * @package Servebolt\Optimizer\Exceptions\ErrorTranslator
+ */
+class CloudflareErrorTranslation extends ErrorTranslator
+{
+    /**
+     * Translation definitions.
+     *
+     * @var array
+     */
+    protected $definitions = [
+        '1012' => 'This is a translated error',
+    ];
+}

--- a/src/Servebolt/Exceptions/ErrorTranslator/CloudflareErrorTranslation.php
+++ b/src/Servebolt/Exceptions/ErrorTranslator/CloudflareErrorTranslation.php
@@ -14,6 +14,6 @@ class CloudflareErrorTranslation extends ErrorTranslator
      * @var array
      */
     protected $definitions = [
-        '1012' => 'This is a translated error',
+        //'1012' => 'This is a translated error',
     ];
 }

--- a/src/Servebolt/Exceptions/ErrorTranslator/ErrorTranslator.php
+++ b/src/Servebolt/Exceptions/ErrorTranslator/ErrorTranslator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions\ErrorTranslator;
+
+/**
+ * Class ErrorTranslator
+ * @package Servebolt\Optimizer\Exceptions\ErrorTranslator
+ */
+abstract class ErrorTranslator
+{
+
+    /**
+     * @var array
+     */
+    protected $errors;
+
+    /**
+     * ErrorTranslator constructor.
+     * @param $errors
+     */
+    public function __construct($errors)
+    {
+        $this->errors = $errors;
+    }
+
+    /**
+     * Attempt to translate error messages to something more user friendly.
+     *
+     * @return array
+     */
+    public function translate(): array
+    {
+        return array_map(function($error) {
+            if (array_key_exists($error->code, $this->definitions)) {
+                $error->original_message = $error->message;
+                $error->message = $this->definitions[$error->code];
+            }
+            return $error;
+        }, $this->errors);
+    }
+}

--- a/src/Servebolt/Exceptions/ErrorTranslator/ServeboltErrorTranslation.php
+++ b/src/Servebolt/Exceptions/ErrorTranslator/ServeboltErrorTranslation.php
@@ -14,6 +14,6 @@ class ServeboltErrorTranslation extends ErrorTranslator
      * @var array
      */
     protected $definitions = [
-        '1012' => 'This is a translated error',
+        //'1012' => 'This is a translated error',
     ];
 }

--- a/src/Servebolt/Exceptions/ErrorTranslator/ServeboltErrorTranslation.php
+++ b/src/Servebolt/Exceptions/ErrorTranslator/ServeboltErrorTranslation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions\ErrorTranslator;
+
+/**
+ * Class ServeboltErrorTranslation
+ * @package Servebolt\Optimizer\Exceptions\ErrorTranslator
+ */
+class ServeboltErrorTranslation extends ErrorTranslator
+{
+    /**
+     * Translation definitions.
+     *
+     * @var array
+     */
+    protected $definitions = [
+        '1012' => 'This is a translated error',
+    ];
+}

--- a/src/Servebolt/Exceptions/MessageTranslator/CloudflareMessageTranslation.php
+++ b/src/Servebolt/Exceptions/MessageTranslator/CloudflareMessageTranslation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions\MessageTranslator;
+
+/**
+ * Class CloudflareMessageTranslation
+ * @package Servebolt\Optimizer\Exceptions\MessageTranslator
+ */
+class CloudflareMessageTranslation extends MessageTranslator
+{
+    /**
+     * Translation definitions.
+     *
+     * @var array
+     */
+    protected $definitions = [
+        '1012' => 'This is a translated message',
+    ];
+}

--- a/src/Servebolt/Exceptions/MessageTranslator/MessageTranslator.php
+++ b/src/Servebolt/Exceptions/MessageTranslator/MessageTranslator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions\MessageTranslator;
+
+/**
+ * Class MessageTranslator
+ * @package Servebolt\Optimizer\Exceptions\MessageTranslator
+ */
+abstract class MessageTranslator
+{
+
+    /**
+     * @var array
+     */
+    protected $messages;
+
+    /**
+     * MessageTranslator constructor.
+     * @param $messages
+     */
+    public function __construct($messages)
+    {
+        $this->messages = $messages;
+    }
+
+    /**
+     * Attempt to translate messages to something more user friendly.
+     *
+     * @return array
+     */
+    public function translate(): array
+    {
+        return array_map(function($message) {
+            if (array_key_exists($message->code, $this->definitions)) {
+                $message->original_message = $message->message;
+                $message->message = $this->definitions[$message->code];
+            }
+            return $message;
+        }, $this->messages);
+    }
+}

--- a/src/Servebolt/Exceptions/MessageTranslator/ServeboltMessageTranslation.php
+++ b/src/Servebolt/Exceptions/MessageTranslator/ServeboltMessageTranslation.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions\MessageTranslator;
+
+/**
+ * Class ServeboltMessageTranslation
+ * @package Servebolt\Optimizer\Exceptions\MessageTranslator
+ */
+class ServeboltMessageTranslation extends MessageTranslator
+{
+    /**
+     * Translation definitions.
+     *
+     * @var array
+     */
+    protected $definitions = [
+        '1012' => 'This is a translated message',
+    ];
+}

--- a/src/Servebolt/Exceptions/QueueError.php
+++ b/src/Servebolt/Exceptions/QueueError.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions;
+
+use Exception;
+
+class QueueError extends Exception
+{
+}

--- a/src/Servebolt/Exceptions/ServeboltApiError.php
+++ b/src/Servebolt/Exceptions/ServeboltApiError.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Servebolt\Optimizer\Exceptions;
+
+/**
+ * Class ServeboltApiError
+ * @package Servebolt\Optimizer\Exceptions
+ */
+class ServeboltApiError extends ApiError
+{
+
+    /**
+     * ApiError constructor.
+     * @param array $errors
+     * @param mixed $response
+     */
+    public function __construct(array $errors, $response)
+    {
+        parent::__construct($errors, 'acd', $response);
+    }
+}

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
@@ -98,7 +98,7 @@ trait CachePurge
             'zones/' . $zoneId . '/purge_cache',
             'POST',
             [
-                //'purge_everything' => true,
+                'purge_everything' => true,
             ]
         );
         if ($this->wasSuccessful($response)) {

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
@@ -20,7 +20,7 @@ trait CachePurge
         }
 
         // Check whether we should purge all
-        $should_purge_all = in_array('all', $urls);
+        $shouldPurgeAll = in_array('all', $urls);
 
         // Maybe alter URL's before sending to CF?
         $urls = apply_filters('sb_optimizer_urls_to_be_purged', $urls);
@@ -38,10 +38,10 @@ trait CachePurge
         } );
 
         // Purge all, return error if we cannot execute
-        if ( $should_purge_all ) {
-            $purge_all_request = $this->purgeAll($zoneId);
-            if ( $purge_all_request !== true ) {
-                return $purge_all_request;
+        if ($shouldPurgeAll) {
+            $purgeAllRequest = $this->purgeAll($zoneId);
+            if ( $purgeAllRequest !== true ) {
+                return $purgeAllRequest;
             }
         }
 

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
@@ -2,14 +2,22 @@
 
 namespace Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods;
 
+use Servebolt\Optimizer\Exceptions\ApiError;
+use Exception;
+
+/**
+ * Trait CachePurge
+ * @package Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods
+ */
 trait CachePurge
 {
+
     /**
      * Purge one or more URL's in a zone.
-     **
-     * @param array $urls
      *
-     * @return bool|void
+     * @param array $urls
+     * @return bool
+     * @throws ApiError
      */
     public function purgeUrls(array $urls)
     {
@@ -54,16 +62,19 @@ trait CachePurge
             }
             return false;
         } catch (Exception $e) {
-            return sb_cf_error($e);
+            throw new ApiError(
+                $this->getErrorsFromRequest($request),
+                $request
+            );
         }
     }
 
     /**
      * Purge all URL's in a zone.
      *
-     * @param bool $zoneId
-     *
+     * @param false $zoneId
      * @return bool
+     * @throws ApiError
      */
     public function purgeAll($zoneId = false)
     {
@@ -75,14 +86,18 @@ trait CachePurge
         }
         try {
             $request = $this->request('zones/' . $zoneId . '/purge_cache', 'POST', [
-                'purge_everything' => true,
+                //'purge_everything' => true,
             ]);
+            print_r($request['json']);die;
             if ( isset($request['json']->result->id) ) {
                 return true;
             }
             return false;
         } catch (Exception $e) {
-            return sb_cf_error($e);
+            throw new ApiError(
+                $this->getErrorsFromRequest($request),
+                $request
+            );
         }
     }
 }

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
@@ -98,7 +98,7 @@ trait CachePurge
             'zones/' . $zoneId . '/purge_cache',
             'POST',
             [
-                'purge_everything' => true,
+                //'purge_everything' => true,
             ]
         );
         if ($this->wasSuccessful($response)) {

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/User.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/User.php
@@ -2,14 +2,22 @@
 
 namespace Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods;
 
+use Servebolt\Optimizer\Exceptions\ApiError;
+use Exception;
+
+/**
+ * Trait User
+ * @package Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods
+ */
 trait User
 {
+
     /**
      * Verify API token.
      *
-     * @param bool $token
-     *
+     * @param false $token
      * @return bool
+     * @throws ApiError
      */
     public function verifyApiToken($token = false) {
         if ( ! $token ) {
@@ -21,14 +29,18 @@ trait User
             ]);
             return $request['httpCode'] === 200;
         } catch (Exception $e) {
-            return sb_cf_error($e);
+            throw new ApiError(
+                $this->getErrorsFromRequest($request),
+                $request
+            );
         }
     }
 
     /**
      * Get user ID of authenticated user.
      *
-     * @return mixed
+     * @return false
+     * @throws ApiError
      */
     public function getUserId()
     {
@@ -40,6 +52,7 @@ trait User
      * Get user details of authenticated user.
      *
      * @return mixed
+     * @throws ApiError
      */
     public function getUserDetails()
     {
@@ -47,7 +60,10 @@ trait User
             $request = $this->request('user');
             return $request['json']->result;
         } catch (Exception $e) {
-            return sb_cf_error($e);
+            throw new ApiError(
+                $this->getErrorsFromRequest($request),
+                $request
+            );
         }
     }
 
@@ -55,6 +71,7 @@ trait User
      * Verify that we can fetch the user.
      *
      * @return bool
+     * @throws ApiError
      */
     public function verifyUser() : bool
     {

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/User.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/User.php
@@ -2,9 +2,6 @@
 
 namespace Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods;
 
-use Servebolt\Optimizer\Exceptions\ApiError;
-use Exception;
-
 /**
  * Trait User
  * @package Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods
@@ -17,30 +14,21 @@ trait User
      *
      * @param false $token
      * @return bool
-     * @throws ApiError
      */
     public function verifyApiToken($token = false) {
         if ( ! $token ) {
             $token = $this->getCredential('api_token');
         }
-        try {
-            $request = $this->request('user/tokens/verify', 'GET', [], [
-                'Authorization' => 'Bearer ' . $token,
-            ]);
-            return $request['httpCode'] === 200;
-        } catch (Exception $e) {
-            throw new ApiError(
-                $this->getErrorsFromRequest($request),
-                $request
-            );
-        }
+        $response = $this->request('user/tokens/verify', 'GET', [], [
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+        return $response['httpCode'] === 200;
     }
 
     /**
      * Get user ID of authenticated user.
      *
      * @return false
-     * @throws ApiError
      */
     public function getUserId()
     {
@@ -52,26 +40,17 @@ trait User
      * Get user details of authenticated user.
      *
      * @return mixed
-     * @throws ApiError
      */
     public function getUserDetails()
     {
-        try {
-            $request = $this->request('user');
-            return $request['json']->result;
-        } catch (Exception $e) {
-            throw new ApiError(
-                $this->getErrorsFromRequest($request),
-                $request
-            );
-        }
+        $request = $this->request('user');
+        return $request['json']->result;
     }
 
     /**
      * Verify that we can fetch the user.
      *
      * @return bool
-     * @throws ApiError
      */
     public function verifyUser() : bool
     {

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/User.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/User.php
@@ -17,7 +17,7 @@ trait User
      */
     public function verifyApiToken($token = false) {
         if ( ! $token ) {
-            $token = $this->getCredential('api_token');
+            $token = $this->getCredential('apiToken');
         }
         $response = $this->request('user/tokens/verify', 'GET', [], [
             'Authorization' => 'Bearer ' . $token,

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/Zone.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/Zone.php
@@ -2,12 +2,21 @@
 
 namespace Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods;
 
+use Servebolt\Optimizer\Exceptions\ApiError;
+use Exception;
+
+/**
+ * Trait Zone
+ * @package Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods
+ */
 trait Zone
 {
+
     /**
      * List zones.
      *
-     * @return bool|stdClass
+     * @return mixed
+     * @throws ApiError
      */
     public function listZones()
     {
@@ -20,7 +29,10 @@ trait Zone
             $request = $this->request('zones', 'GET', $query);
             return $request['json']->result;
         } catch (Exception $e) {
-            return sb_cf_error($e);
+            throw new ApiError(
+                $this->getErrorsFromRequest($request),
+                $request
+            );
         }
     }
 
@@ -28,8 +40,8 @@ trait Zone
      * Check if zone exists.
      *
      * @param string $zoneId
-     *
      * @return bool
+     * @throws ApiError
      */
     protected function zoneExists(string $zoneId) : bool
     {
@@ -40,8 +52,8 @@ trait Zone
      * Get zone by Id.
      *
      * @param string $zoneId
-     *
-     * @return bool|object
+     * @return mixed
+     * @throws ApiError
      */
     public function getZoneById(string $zoneId)
     {
@@ -49,7 +61,10 @@ trait Zone
             $request = $this->request('zones/' . $zoneId);
             return $request['json']->result;
         } catch (Exception $e) {
-            return sb_cf_error($e);
+            throw new ApiError(
+                $this->getErrorsFromRequest($request),
+                $request
+            );
         }
     }
 
@@ -58,8 +73,8 @@ trait Zone
      *
      * @param string $zoneName
      * @param string $key
-     *
-     * @return bool
+     * @return bool|mixed
+     * @throws ApiError
      */
     public function getZoneByKey(string $zoneName, string $key = 'name')
     {

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/Zone.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/Zone.php
@@ -12,9 +12,10 @@ trait Zone
     /**
      * List zones.
      *
+     * @param array|null $filterColumns
      * @return mixed
      */
-    public function listZones()
+    public function listZones(?array $filterColumns = null)
     {
         $query = [
             'page'     => 1,
@@ -22,7 +23,17 @@ trait Zone
             'match'    => 'all'
         ];
         $request = $this->request('zones', 'GET', $query);
-        return $request['json']->result;
+        $zones = $request['json']->result;
+        if ($filterColumns) {
+            $zones = array_map(function($zone) use($filterColumns) {
+                $filteredZone = [];
+                foreach($filterColumns as $column) {
+                    $filteredZone[$column] = isset($zone->{$column}) ? $zone->{$column} : null;
+                }
+                return (object) $filteredZone;
+            }, $zones);
+        }
+        return $zones;
     }
 
     /**

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/Zone.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/Zone.php
@@ -2,9 +2,6 @@
 
 namespace Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods;
 
-use Servebolt\Optimizer\Exceptions\ApiError;
-use Exception;
-
 /**
  * Trait Zone
  * @package Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods
@@ -16,7 +13,6 @@ trait Zone
      * List zones.
      *
      * @return mixed
-     * @throws ApiError
      */
     public function listZones()
     {
@@ -25,15 +21,8 @@ trait Zone
             'per_page' => 20,
             'match'    => 'all'
         ];
-        try {
-            $request = $this->request('zones', 'GET', $query);
-            return $request['json']->result;
-        } catch (Exception $e) {
-            throw new ApiError(
-                $this->getErrorsFromRequest($request),
-                $request
-            );
-        }
+        $request = $this->request('zones', 'GET', $query);
+        return $request['json']->result;
     }
 
     /**
@@ -41,7 +30,6 @@ trait Zone
      *
      * @param string $zoneId
      * @return bool
-     * @throws ApiError
      */
     protected function zoneExists(string $zoneId) : bool
     {
@@ -53,19 +41,11 @@ trait Zone
      *
      * @param string $zoneId
      * @return mixed
-     * @throws ApiError
      */
     public function getZoneById(string $zoneId)
     {
-        try {
-            $request = $this->request('zones/' . $zoneId);
-            return $request['json']->result;
-        } catch (Exception $e) {
-            throw new ApiError(
-                $this->getErrorsFromRequest($request),
-                $request
-            );
-        }
+        $request = $this->request('zones/' . $zoneId);
+        return $request['json']->result;
     }
 
     /**
@@ -74,7 +54,6 @@ trait Zone
      * @param string $zoneName
      * @param string $key
      * @return bool|mixed
-     * @throws ApiError
      */
     public function getZoneByKey(string $zoneName, string $key = 'name')
     {

--- a/src/Servebolt/Sdk/Cloudflare/ApiRequestHelpers.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiRequestHelpers.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Servebolt\Optimizer\Sdk\Cloudflare;
+
+trait ApiRequestHelpers
+{
+    /**
+     * @param $request
+     * @return array
+     */
+    protected function getErrorsFromRequest($request): array
+    {
+        // TODO: Parse errors from request into array compatible with the ApiError-exception
+        var_dump($request);die;
+        return [];
+    }
+}

--- a/src/Servebolt/Sdk/Cloudflare/ApiRequestHelpers.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiRequestHelpers.php
@@ -2,16 +2,35 @@
 
 namespace Servebolt\Optimizer\Sdk\Cloudflare;
 
-trait ApiRequestHelpers
+class ApiRequestHelpers
 {
     /**
+     * Extract the errors from the request.
+     *
      * @param $request
      * @return array
      */
-    protected function getErrorsFromRequest($request): array
+    public static function getErrorsFromRequest($request): array
     {
-        // TODO: Parse errors from request into array compatible with the ApiError-exception
-        var_dump($request);die;
+        $response = $request['json'];
+        if (isset($response->errors) && is_array($response->errors)) {
+            return $response->errors;
+        }
+        return [];
+    }
+
+    /**
+     * Extract the messages from the request.
+     *
+     * @param $request
+     * @return array
+     */
+    public static function getMessagesFromRequest($request): array
+    {
+        $response = $request['json'];
+        if (isset($response->errors) && is_array($response->errors)) {
+            return $response->errors;
+        }
         return [];
     }
 }

--- a/src/Servebolt/Sdk/Cloudflare/Cloudflare.php
+++ b/src/Servebolt/Sdk/Cloudflare/Cloudflare.php
@@ -17,7 +17,7 @@ use Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods\User as UserMethods;
 class Cloudflare extends HttpClient
 {
 
-    use CachePurgeMethods, ZoneMethods, UserMethods;
+    use CachePurgeMethods, ZoneMethods, UserMethods, ApiRequestHelpers;
 
     /**
      * Cloudflare API credentials.
@@ -56,7 +56,7 @@ class Cloudflare extends HttpClient
         if ($this->credentialsOk($args)) {
             $this->setCredentials($args['authType'], $args['credentials']);
             if ($this->zoneOk($args)) {
-                $this->setZoneId($args['ZoneId']);
+                $this->setZoneId($args['zoneId']);
             }
         }
     }
@@ -70,7 +70,7 @@ class Cloudflare extends HttpClient
     private function zoneOk($args): bool
     {
         return is_array($args)
-            && array_key_exists('ZoneId', $args);
+            && array_key_exists('zoneId', $args);
     }
 
     /**

--- a/src/Servebolt/Sdk/Cloudflare/Cloudflare.php
+++ b/src/Servebolt/Sdk/Cloudflare/Cloudflare.php
@@ -17,7 +17,7 @@ use Servebolt\Optimizer\Sdk\Cloudflare\ApiMethods\User as UserMethods;
 class Cloudflare extends HttpClient
 {
 
-    use CachePurgeMethods, ZoneMethods, UserMethods, ApiRequestHelpers;
+    use CachePurgeMethods, ZoneMethods, UserMethods;
 
     /**
      * Cloudflare API credentials.

--- a/src/Servebolt/Sdk/Cloudflare/Exceptions/ApiError.php
+++ b/src/Servebolt/Sdk/Cloudflare/Exceptions/ApiError.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Servebolt\Optimizer\Sdk\Cloudflare\Exceptions;
+
+use Exception;
+
+/**
+ * Class ApiError
+ * @package Servebolt\Optimizer\Exceptions
+ */
+class ApiError extends Exception
+{
+
+    /**
+     * An array of error(s).
+     *
+     * @var array
+     */
+    protected $errors;
+
+    /**
+     * The response object for the driver.
+     *
+     * @var mixed
+     */
+    protected $response;
+
+    /**
+     * ApiError constructor.
+     * @param array $errors
+     * @param mixed $response
+     */
+    public function __construct(array $errors, $response)
+    {
+        $this->errors = $errors;
+        $this->response = $response;
+    }
+
+    /**
+     * Get errors.
+     *
+     * @return array
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Get the response that communicated the error(s).
+     *
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Servebolt/Traits/ClientMethodProxy.php
+++ b/src/Servebolt/Traits/ClientMethodProxy.php
@@ -2,6 +2,8 @@
 
 namespace Servebolt\Optimizer\Traits;
 
+use Exception;
+
 trait ClientMethodProxy
 {
     /**
@@ -15,6 +17,23 @@ trait ClientMethodProxy
             return call_user_func_array([$this->client, $name], $arguments);
         } else {
             trigger_error(sprintf('Call to undefined method %s', $name));
+        }
+    }
+
+    /**
+     * @param $name
+     * @return false|mixed
+     */
+    public function __get($name)
+    {
+        if (is_object($this->client)) {
+            try {
+                return $this->client->{$name};
+            } catch (Exception $e) {
+                trigger_error(sprintf('Call to undefined property %s', $name));
+            }
+        } else {
+            trigger_error(sprintf('Call to undefined property %s', $name));
         }
     }
 }

--- a/src/Servebolt/Views/cache-purge/configuration/cache-purge-triggers.php
+++ b/src/Servebolt/Views/cache-purge/configuration/cache-purge-triggers.php
@@ -1,0 +1,14 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly ?>
+<?php $cachePurge = Servebolt\Optimizer\CachePurge\CachePurge::getInstance(); ?>
+
+<?php if ( $cachePurge->cachePurgeIsActive() ) : ?>
+    <?php if ( ! $cachePurge->featureIsConfigured() ) : ?>
+        <p><?php sb_e('Make sure you have added the API credentials and selected a zone to use this functionality.'); ?></p>
+    <?php else: ?>
+        <p>
+            <button class="sb-purge-all-cache sb-button yellow inline"><?php sb_e('Purge all cache'); ?></button>
+            <button class="sb-purge-url sb-button yellow inline"><?php sb_e('Purge a URL'); ?></button>
+        </p>
+        <br>
+    <?php endif; ?>
+<?php endif; ?>

--- a/src/Servebolt/Views/cache-purge/configuration/cache-purge-triggers.php
+++ b/src/Servebolt/Views/cache-purge/configuration/cache-purge-triggers.php
@@ -1,8 +1,8 @@
 <?php if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly ?>
-<?php $cachePurge = Servebolt\Optimizer\CachePurge\CachePurge::getInstance(); ?>
+<?php use Servebolt\Optimizer\CachePurge\CachePurge; ?>
 
-<?php if ( $cachePurge->cachePurgeIsActive() ) : ?>
-    <?php if ( ! $cachePurge->featureIsConfigured() ) : ?>
+<?php if (CachePurge::cachePurgeIsActive()) : ?>
+    <?php if (!CachePurge::featureIsConfigured()) : ?>
         <p><?php sb_e('Make sure you have added the API credentials and selected a zone to use this functionality.'); ?></p>
     <?php else: ?>
         <p>

--- a/src/Servebolt/Views/cache-purge/configuration/cloudflare-configuration.php
+++ b/src/Servebolt/Views/cache-purge/configuration/cloudflare-configuration.php
@@ -19,11 +19,11 @@
         </td>
     </tr>
     <tr class="feature_cf_auth_type-api_token"<?php if ( $settings['cf_auth_type'] != 'api_token' ) echo ' style="display: none;"' ?>>
-        <th scope="row"><label for="sb_api_token"><?php sb_e('API token'); ?></label></th>
+        <th scope="row"><label for="sb_cf_api_token"><?php sb_e('API token'); ?></label></th>
         <td>
 
             <div class="sb-pwd">
-                <input name="<?php echo sb_get_option_name('cf_api_token'); ?>" type="password" id="sb_api_token" autocomplete="off" data-original-value="<?php echo esc_attr($settings['cf_api_token']); ?>" value="<?php echo esc_attr($settings['cf_api_token']); ?>" class="regular-text validate-field validation-group-api_token validation-group-api_credentials">
+                <input name="<?php echo sb_get_option_name('cf_api_token'); ?>" type="password" id="sb_cf_api_token" autocomplete="off" data-original-value="<?php echo esc_attr($settings['cf_api_token']); ?>" value="<?php echo esc_attr($settings['cf_api_token']); ?>" class="regular-text validate-field validation-group-api_token validation-group-api_credentials">
                 <button type="button" class="button button-secondary wp-hide-pw sb-hide-pwd hide-if-no-js" data-toggle="0" aria-label="Show password">
                     <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
                 </button>
@@ -34,17 +34,17 @@
         </td>
     </tr>
     <tr class="feature_cf_auth_type-api_key"<?php if ( $settings['cf_auth_type'] != 'api_key' ) echo ' style="display: none;"' ?>>
-        <th scope="row"><label for="sb_email"><?php sb_e('Cloudflare e-mail'); ?></label></th>
+        <th scope="row"><label for="sb_cf_email"><?php sb_e('Cloudflare e-mail'); ?></label></th>
         <td>
-            <input name="<?php echo sb_get_option_name('cf_email'); ?>" type="text" id="sb_email" autocomplete="off" data-original-value="<?php echo esc_attr($settings['cf_email']); ?>" value="<?php echo esc_attr($settings['cf_email']); ?>" class="regular-text validate-field validation-input-email validation-group-api_key_credentials validation-group-api_credentials">
+            <input name="<?php echo sb_get_option_name('cf_email'); ?>" type="text" id="sb_cf_email" autocomplete="off" data-original-value="<?php echo esc_attr($settings['cf_email']); ?>" value="<?php echo esc_attr($settings['cf_email']); ?>" class="regular-text validate-field validation-input-email validation-group-api_key_credentials validation-group-api_credentials">
             <p class="invalid-message"></p>
         </td>
     </tr>
     <tr class="feature_cf_auth_type-api_key"<?php if ( $settings['cf_auth_type'] != 'api_key' ) echo ' style="display: none;"' ?>>
-        <th scope="row"><label for="sb_api_key"><?php sb_e('API key'); ?></label></th>
+        <th scope="row"><label for="sb_cf_api_key"><?php sb_e('API key'); ?></label></th>
         <td>
             <div class="sb-pwd">
-                <input name="<?php echo sb_get_option_name('cf_api_key'); ?>" type="password" id="sb_api_key" autocomplete="off" data-original-value="<?php echo esc_attr($settings['cf_api_key']); ?>" value="<?php echo esc_attr($settings['cf_api_key']); ?>" class="regular-text validate-field validation-input-api_key validation-group-api_key_credentials validation-group-api_credentials">
+                <input name="<?php echo sb_get_option_name('cf_api_key'); ?>" type="password" id="sb_cf_api_key" autocomplete="off" data-original-value="<?php echo esc_attr($settings['cf_api_key']); ?>" value="<?php echo esc_attr($settings['cf_api_key']); ?>" class="regular-text validate-field validation-input-api_key validation-group-api_key_credentials validation-group-api_credentials">
                 <button type="button" class="button button-secondary wp-hide-pw sb-hide-pwd hide-if-no-js" data-toggle="0" aria-label="Show password">
                     <span class="dashicons dashicons-visibility" aria-hidden="true"></span>
                 </button>
@@ -63,10 +63,10 @@
         <td>
 
             <?php
-            $zone = false;//$settings['cf_zone_id'] ? sb_cf_cache()->getZoneById($settings['cf_zone_id']) : false;
-            $have_zones = false;
-            $zones = [];//sb_cf_cache()->list_zones();
-            $have_zones = ( is_array($zones) && ! empty($zones) );
+                $zone = $settings['cf_zone_id'] ? $cfApi->getZoneById($settings['cf_zone_id']) : false;
+                $have_zones = false;
+                $zones = [];//sb_cf_cache()->list_zones();
+                $have_zones = ( is_array($zones) && ! empty($zones) );
             ?>
 
             <input name="<?php echo sb_get_option_name('cf_zone_id'); ?>" type="text" id="zone_id" placeholder="Type zone ID<?php if ( $have_zones ) echo ' or use the choices below'; ?>" value="<?php echo esc_attr($settings['cf_zone_id']); ?>" class="regular-text validate-field validation-group-zone_id">

--- a/src/Servebolt/Views/cache-purge/configuration/cloudflare-configuration.php
+++ b/src/Servebolt/Views/cache-purge/configuration/cloudflare-configuration.php
@@ -62,25 +62,19 @@
         <th scope="row"><label for="zone_id"><?php sb_e('Zone ID'); ?></label></th>
         <td>
 
-            <?php
-                $zone = $settings['cf_zone_id'] ? $cfApi->getZoneById($settings['cf_zone_id']) : false;
-                $have_zones = false;
-                $zones = [];//sb_cf_cache()->list_zones();
-                $have_zones = ( is_array($zones) && ! empty($zones) );
-            ?>
-
-            <input name="<?php echo sb_get_option_name('cf_zone_id'); ?>" type="text" id="zone_id" placeholder="Type zone ID<?php if ( $have_zones ) echo ' or use the choices below'; ?>" value="<?php echo esc_attr($settings['cf_zone_id']); ?>" class="regular-text validate-field validation-group-zone_id">
+            <?php $haveZones = (is_array($cfZones) && !empty($cfZones)); ?>
+            <input name="<?php echo sb_get_option_name('cf_zone_id'); ?>" type="text" id="zone_id" placeholder="Type zone ID<?php if ($haveZones) echo ' or use the choices below'; ?>" value="<?php echo esc_attr($settings['cf_zone_id']); ?>" class="regular-text validate-field validation-group-zone_id">
             <span class="spinner zone-loading-spinner"></span>
             <p class="invalid-message"></p>
 
-            <p class="active-zone"<?php if ( ! isset($zone) || ! $zone ) echo ' style="display: none;"'; ?>><?php sb_e('Selected zone:'); ?> <span><?php if ( isset($zone) && $zone ) echo $zone->name; ?></span></p>
+            <p class="active-zone"<?php if ( ! isset($selectedCfZone) || ! $selectedCfZone ) echo ' style="display: none;"'; ?>><?php sb_e('Selected zone:'); ?> <span><?php if ( isset($selectedCfZone) && $selectedCfZone ) echo $selectedCfZone->name; ?></span></p>
 
-            <div class="zone-selector-container"<?php if ( ! $have_zones ) echo ' style="display: none;"'; ?>>
+            <div class="zone-selector-container"<?php if ( ! $haveZones ) echo ' style="display: none;"'; ?>>
                 <p style="margin-top: 10px;"><?php sb_e('Available zones:'); ?></p>
                 <ul class="zone-selector" style="margin: 5px 0;">
-                    <?php if ( $have_zones ) : ?>
-                        <?php foreach($zones as $zone) : ?>
-                            <li><a href="#" data-name="<?php echo esc_attr($zone->name); ?>" data-id="<?php echo esc_attr($zone->id); ?>"><?php echo $zone->name; ?> (<?php echo $zone->id; ?>)</a></li>
+                    <?php if ($haveZones) : ?>
+                        <?php foreach($cfZones as $cfZone) : ?>
+                            <li><a href="#" data-name="<?php echo esc_attr($cfZone->name); ?>" data-id="<?php echo esc_attr($cfZone->id); ?>"><?php echo $cfZone->name; ?> (<?php echo $cfZone->id; ?>)</a></li>
                         <?php endforeach; ?>
                     <?php endif; ?>
                 </ul>

--- a/src/Servebolt/Views/cache-purge/configuration/configuration.php
+++ b/src/Servebolt/Views/cache-purge/configuration/configuration.php
@@ -1,6 +1,5 @@
 <?php if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly ?>
 <?php use function Servebolt\Optimizer\Helpers\view; ?>
-<?php $cachePurge = Servebolt\Optimizer\CachePurge\CachePurge::getInstance(); ?>
 
 <?php settings_errors(); ?>
 
@@ -14,31 +13,7 @@
 
 <p><?php sb_e('This feature will automatically purge the cache whenever you do an update in WordPress. Neat right?'); ?></p>
 
-<?php if ( $cachePurge->cachePurgeIsActive() ) : ?>
-    <?php if ( ! $cachePurge->featureIsConfigured() ) : ?>
-        <p><?php sb_e('Make sure you have added the API credentials and selected a zone to use this functionality.'); ?></p>
-    <?php else: ?>
-        <p>
-            <button class="sb-purge-all-cache sb-button yellow inline"><?php sb_e('Purge all cache'); ?></button>
-            <button class="sb-purge-url sb-button yellow inline"><?php sb_e('Purge a URL'); ?></button>
-        </p>
-        <br>
-    <?php endif; ?>
-<?php endif; ?>
-
-<?php /*
-    <?php if ( sb_cf_cache()->cf_is_active() ) : ?>
-        <?php if ( ! sb_cf_cache()->cf_cache_feature_available() ) : ?>
-            <p><?php sb_e('Make sure you have added the API credentials and selected a zone to use this functionality.'); ?></p>
-        <?php else: ?>
-            <p>
-                <button class="sb-purge-all-cache sb-button yellow inline"><?php sb_e('Purge all cache'); ?></button>
-                <button class="sb-purge-url sb-button yellow inline"><?php sb_e('Purge a URL'); ?></button>
-            </p>
-            <br>
-        <?php endif; ?>
-    <?php endif; ?>
- */ ?>
+    <?php view('cache-purge.configuration.cache-purge-triggers'); ?>
 
     <h1><?php sb_e('Configuration'); ?></h1>
     <!--<p><?php sb_e('This feature can be set up using WP CLI or with the form below.'); ?></p>-->


### PR DESCRIPTION
After we added support for multiple cache purge drivers then the AJAX-handling of cache purge requests needed to be updated accordingly. This included both the JS-side and the WP AJAX endpoint handling.