### PR TITLE
WPSO-77 Logviewer not found (BUG)

### DIFF
--- a/src/Servebolt/Admin/AdminGuiController.php
+++ b/src/Servebolt/Admin/AdminGuiController.php
@@ -360,7 +360,8 @@ class AdminGuiController
      */
     public function errorLogCallback(): void
     {
-        ( Servebolt_Logviewer::get_instance() )->view();
+        require_once SERVEBOLT_PATH . 'admin/log-viewer.php';
+        ( \Servebolt_Logviewer::get_instance() )->view();
     }
 
     /**


### PR DESCRIPTION
Fixed error where Error log GUI was not shown (due to improper initiaization)