### PR TITLE
WPSO-145 Make tests work again

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -9,10 +9,10 @@ return [
     // 'plugins' => ['UnusedSuppressionPlugin'],
     // List of case-insensitive file extensions supported by Phan.
     // (e.g. php, html, htm)
-    'analyzed_file_extensions' => [ 'php' ],
+    'analyzed_file_extensions' => ['php'],
     'color_issue_messages'     => true,
     'target_php_version'       => '7.3',
-    'globals_type_map'         => [ 'user' => 'object' ],
+    'globals_type_map'         => ['user' => 'object'],
     // A regular expression to match files to be excluded
     // from parsing and analysis and will not be read at all.
     //
@@ -30,6 +30,13 @@ return [
     'exclude_file_list' => [
     ],
 
+    // A list of individual files to include in analysis
+    // with a path relative to the root directory of the
+    // project.
+    'file_list' => [
+        'servebolt-optimizer.php',
+    ],
+
     // A list of directories that should be parsed for class and
     // method information. After excluding the directories
     // defined in exclude_analysis_directory_list, the remaining
@@ -38,7 +45,9 @@ return [
     // Thus, both first-party and third-party code being used by
     // your application should be included in this list.
     'directory_list' => [
-        '.',
+        'vendor/phpunit',
+        'src/',
+        'tests/'
     ],
 
     // A directory list that defines files that will be excluded
@@ -53,7 +62,8 @@ return [
     //       should be added to both the `directory_list`
     //       and `exclude_analysis_directory_list` arrays.
     'exclude_analysis_directory_list' => [
-        'vendor',
-        'wp-sources',
+        'vendor/phpunit',
+        'src/Dependencies/',
+        'tests/bin/',
     ],
 ];

--- a/ci/phan.sh
+++ b/ci/phan.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+echo "Note: Make sure you have the test environment set up, since phan will analyze the tests and thus the test env is needed."
 vendor/bin/phan --no-progress-bar --allow-polyfill-parser

--- a/ci/phpcs.sh
+++ b/ci/phpcs.sh
@@ -2,4 +2,4 @@
 vendor/bin/phpcs --version
 vendor/bin/phpcs -s --standard=PSR1 \
 --exclude=Squiz.CSS.Indentation \
-src tests "$*"
+src/Servebolt tests/Unit tests/Feature assets/src "$*"

--- a/ci/phplint.sh
+++ b/ci/phplint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-vendor/bin/phplint --no-progress --exclude=vendor
+vendor/bin/phplint ./ --no-progress --exclude=vendor --exclude=tests/bin --exclude=src/Dependencies

--- a/composer.json
+++ b/composer.json
@@ -56,13 +56,16 @@
   },
   "scripts": {
     "phpunit": [
-      "./vendor/phpunit/phpunit/phpunit"
+      "./vendor/phpunit/phpunit/phpunit -c phpunit.xml"
     ],
     "phpunit-mu": [
       "./vendor/phpunit/phpunit/phpunit -c phpunit-mu.xml"
     ],
     "install-wp-test": ["ci/install-wp-tests.sh"],
-    "test": ["ci/phpcs.sh","ci/phplint.sh","ci/phan.sh"],
+    "test": ["composer test-phpcs","composer test-phplint","composer test-phan"],
+    "test-phpcs": "ci/phpcs.sh",
+    "test-phplint": "ci/phplint.sh",
+    "test-phan": "ci/phan.sh",
     "post-install-cmd": [
       "[ -f vendor/bin/phpcs ] && \"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs || true",
       "@php mozart.phar compose",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1c669affcbb63a40f6c8e1eebf23464",
+    "content-hash": "ddb89398ae136f7efee3d21efc0bc2c4",
     "packages": [
         {
             "name": "composer/installers",


### PR DESCRIPTION
PHPCS, PHPLint and Phan were misconfigured. This is now fixed. Some work is needed to make them pass.