### PR TITLE
WPSO-125 Add "Purge current term cache" in WP Admin bar dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You should now be able to run ``composer phpunit``.
 
 ### Build assets
 1. Run `yarn install`
-2. Run `yarn build` for local or `yarn production` for production
+2. Run `yarn build` / `yarn watch` for dev build or `yarn production` for production build
 
 ### Phan - static analyzer for PHP
 Phan helps identifying errors in your code.

--- a/assets/src/js/cloudflare-cache-purge-trigger.js
+++ b/assets/src/js/cloudflare-cache-purge-trigger.js
@@ -20,8 +20,18 @@ jQuery(document).ready(function($) {
   $('#wpadminbar .sb-purge-current-post-cache').click(function (e) {
     e.preventDefault();
     sb_close_admin_bar_menu();
-    var postId = $(this).find('span').data('id');
-    window.sb_purge_post_cache(postId);
+    var postId = $(this).find('span').data('id'),
+        objectName = $(this).find('span').data('object-name');
+    window.sb_purge_post_cache(postId, objectName);
+  });
+
+  // Purge current term cache
+  $('#wpadminbar .sb-purge-current-term-cache').click(function (e) {
+    e.preventDefault();
+    sb_close_admin_bar_menu();
+    var termId = $(this).find('span').data('id'),
+        objectName = $(this).find('span').data('object-name');
+    window.sb_purge_term_cache(termId, objectName);
   });
 
   // Purge URL cache
@@ -243,15 +253,22 @@ jQuery(document).ready(function($) {
    * Clear cache by post ID in Cloudflare.
    *
    * @param postId
+   * @param objectName
    */
-  window.sb_purge_post_cache = function(postId) {
+  window.sb_purge_post_cache = function(postId, objectName) {
+    if (objectName) {
+      var confirmText = 'Do you want to purge cache for ' + objectName + '?';
+
+    } else {
+      var confirmText = 'Do you want to purge cache for post?';
+    }
     if (window.sb_use_native_js_fallback()) {
-      if (window.confirm('Do you want to purge cache for current post?')) {
+      if (window.confirm(confirmText)) {
         sb_purge_post_cache_confirmed(postId);
       }
     } else {
       Swal.fire({
-        title: 'Do you want to purge cache for current post?',
+        title: confirmText,
         icon: 'warning',
         showCancelButton: true,
         customClass: {

--- a/src/Servebolt/Admin/AdminBarGUI/AdminBarGUI.php
+++ b/src/Servebolt/Admin/AdminBarGUI/AdminBarGUI.php
@@ -163,7 +163,7 @@ class AdminBarGUI
                     $nodeText = sprintf(__('Purge %s cache', 'servebolt-wp'), $objectName);
                     $nodes[] = [
                         'id'    => 'servebolt-clear-current-term-cache',
-                        'title' => sprintf('<span data-object-name="%s" data-id="%s">%s</span>', $objectName, $postId, $nodeText),
+                        'title' => sprintf('<span data-object-name="%s" data-id="%s">%s</span>', $objectName, $termId, $nodeText),
                         'href'  => '#',
                         'meta'  => [
                             'class' => 'sb-admin-button sb-purge-current-term-cache',

--- a/src/Servebolt/Admin/AdminBarGUI/AdminBarGUI.php
+++ b/src/Servebolt/Admin/AdminBarGUI/AdminBarGUI.php
@@ -28,7 +28,7 @@ class AdminBarGUI
 	 */
 	private function __construct()
     {
-        add_action( 'admin_bar_menu', [ $this, 'adminBar' ], 100 );
+        add_action('admin_bar_menu', [ $this, 'adminBar' ], 100);
 	}
 
 	/**
@@ -92,7 +92,7 @@ class AdminBarGUI
 
 		if ($adminUrl = getServeboltAdminUrl()) {
 			$nodes[] = [
-				'id'    => 'servebolt-crontrol-panel',
+				'id'    => 'servebolt-control-panel',
 				'title' => __('Servebolt Control Panel', 'servebolt-wp'),
 				'href'  => $adminUrl,
 				'meta'  => [
@@ -145,16 +145,31 @@ class AdminBarGUI
 
         if (!is_network_admin()) {
             if ($cachePurgeAvailable) {
-				if ($postId = $this->getSinglePostId()) {
+				if (apply_filters('sb_optimizer_allow_admin_bar_cache_purge_for_post', true) && $postId = $this->getSinglePostId()) {
+				    $objectName = $this->getPostTypeSingularName($postId);
+				    $nodeText = sprintf(__('Purge %s cache', 'servebolt-wp'), $objectName);
 					$nodes[] = [
-						'id'    => 'servebolt-clear-current-cf-cache',
-						'title' => '<span data-id="' . $postId . '">' . __('Purge current post cache', 'servebolt-wp') . '</span>',
+						'id'    => 'servebolt-clear-current-post-cache',
+						'title' => sprintf('<span data-object-name="%s" data-id="%s">%s</span>', $objectName, $postId, $nodeText),
 						'href'  => '#',
 						'meta'  => [
-							'class' => 'sb-admin-button sb-purge-current-post-cache'
+							'class' => 'sb-admin-button sb-purge-current-post-cache',
 						]
 					];
 				}
+
+                if (apply_filters('sb_optimizer_allow_admin_bar_cache_purge_term_post', true) && $termId = $this->getSingleTermId()) {
+                    $objectName = $this->getTaxonomySingularName($termId);
+                    $nodeText = sprintf(__('Purge %s cache', 'servebolt-wp'), $objectName);
+                    $nodes[] = [
+                        'id'    => 'servebolt-clear-current-term-cache',
+                        'title' => sprintf('<span data-object-name="%s" data-id="%s">%s</span>', $objectName, $postId, $nodeText),
+                        'href'  => '#',
+                        'meta'  => [
+                            'class' => 'sb-admin-button sb-purge-current-term-cache',
+                        ]
+                    ];
+                }
 			}
 		}
 
@@ -171,8 +186,44 @@ class AdminBarGUI
 		return $nodes;
 	}
 
+    /**
+     * Get post type singular name.
+     *
+     * @param int $postId
+     * @return string
+     */
+	private function getPostTypeSingularName(int $postId): string
+    {
+        if ($postType = get_post_type($postId)) {
+            if ($postTypeObject = get_post_type_object($postType)) {
+                if (isset($postTypeObject->labels->singular_name) && $postTypeObject->labels->singular_name) {
+                    return mb_strtolower($postTypeObject->labels->singular_name);
+                }
+            }
+        }
+        return 'post';
+    }
+
+    /**
+     * Get taxonomy singular name by term.
+     *
+     * @param int $termId
+     * @return string
+     */
+    private function getTaxonomySingularName(int $termId): string
+    {
+        if ($term = get_term($termId)) {
+            if ($taxonomyObject = get_taxonomy($term->taxonomy)) {
+                if (isset($taxonomyObject->labels->singular_name) && $taxonomyObject->labels->singular_name) {
+                    return mb_strtolower($taxonomyObject->labels->singular_name);
+                }
+            }
+        }
+        return 'term';
+    }
+
 	/**
-	 * Check whether we should allow post purge of current post (if there is any).
+	 * Check whether we should allow cache purge of current post (if there is any).
 	 *
      * @return int|null
      */
@@ -184,6 +235,28 @@ class AdminBarGUI
 		global $post, $pagenow;
 		if (is_admin() && $pagenow == 'post.php' && $post->ID) {
 			return $post->ID;
+		}
+		return null;
+	}
+
+    /**
+	 * Check whether we should allow cache purge of current term (if there is any).
+	 *
+     * @return int|null
+     */
+	private function getSingleTermId(): ?int
+    {
+        if (!is_admin()) {
+            $queriedObject = get_queried_object();
+            if (is_a($queriedObject, 'WP_Term')) {
+                return $queriedObject->term_id;
+            }
+        }
+		global $pagenow;
+		if (is_admin() && $pagenow == 'term.php') {
+            if ($termId = absint($_REQUEST['tag_ID'])) {
+                return $termId;
+            }
 		}
 		return null;
 	}

--- a/src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php
+++ b/src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php
@@ -216,8 +216,9 @@ class PurgeActions extends SharedAjaxMethods
 
         $queueBasedCachePurgeIsActive = CachePurge::queueBasedCachePurgeIsActive();
         try {
-            $termName = get_term($termId)->name;
-            WordPressCachePurge::purgeByTerm($termId);
+            $term = get_term($termId);
+            $termName = $term->name;
+            WordPressCachePurge::purgeByTerm($termId, $term->taxonomy);
             if ($queueBasedCachePurgeIsActive) {
                 wp_send_json_success( [
                     'title'   => 'Just a moment',

--- a/src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php
+++ b/src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php
@@ -31,6 +31,7 @@ class PurgeActions extends SharedAjaxMethods
         add_action('wp_ajax_servebolt_purge_all_cache', [$this, 'purgeAllCacheCallback']);
         add_action('wp_ajax_servebolt_purge_url_cache', [$this, 'purgeUrlCacheCallback']);
         add_action('wp_ajax_servebolt_purge_post_cache', [$this, 'purgePostCacheCallback']);
+        add_action('wp_ajax_servebolt_purge_term_cache', [$this, 'purgeTermCacheCallback']);
         /*
         // TODO: Make this feature work with the new cache purge driver
         if ( is_multisite() ) {
@@ -150,7 +151,7 @@ class PurgeActions extends SharedAjaxMethods
     }
 
     /**
-     * Purge specific post in Cloudflare cache.
+     * Purge cache for post.
      */
     public function purgePostCacheCallback() : void
     {
@@ -177,7 +178,53 @@ class PurgeActions extends SharedAjaxMethods
                     'message' => sprintf(__('A cache purge-request for the post "%s" was added to the queue and will be executed shortly.', 'servebolt-wp'), get_the_title($postId)),
                 ] );
             } else {
-                wp_send_json_success(['message' => sprintf(__('Cache was purged for the post post "%s".', 'servebolt-wp'), get_the_title($postId))]);
+                wp_send_json_success(['message' => sprintf(__('Cache was purged for the post "%s".', 'servebolt-wp'), get_the_title($postId))]);
+            }
+        } catch (QueueError $e) {
+            // TODO: Handle response from queue system
+        } catch (ApiMessage $e) {
+            // TODO: Handle messages from API.
+        } catch (ApiError $e) {
+            if ($e->hasMultipleErrors()) {
+                wp_send_json_error($e->getErrors());
+            } else {
+                wp_send_json_error(['message' => $e->getMessage()]);
+            }
+        } catch (Exception $e) {
+            wp_send_json_error(['message' => $e->getMessage()]);
+        }
+    }
+
+    /**
+     * Purge cache for term.
+     */
+    public function purgeTermCacheCallback() : void
+    {
+        $this->checkAjaxReferer();
+        ajaxUserAllowed();
+        $termId = intval(arrayGet('term_id', $_POST));
+
+        $this->ensureCachePurgeFeatureIsActive();
+
+        if (!$termId || empty($termId)) {
+            wp_send_json_error(['message' => 'Please specify the term you would like to purge cache for.']);
+            return;
+        } elseif (!term_exists($termId)) {
+            wp_send_json_error(['message' => 'The specified term does not exist.']);
+            return;
+        }
+
+        $queueBasedCachePurgeIsActive = CachePurge::queueBasedCachePurgeIsActive();
+        try {
+            $termName = get_term($termId)->name;
+            WordPressCachePurge::purgeByTerm($termId);
+            if ($queueBasedCachePurgeIsActive) {
+                wp_send_json_success( [
+                    'title'   => 'Just a moment',
+                    'message' => sprintf(__('A cache purge-request for the term "%s" was added to the queue and will be executed shortly.', 'servebolt-wp'), $termName),
+                ] );
+            } else {
+                wp_send_json_success(['message' => sprintf(__('Cache was purged for the term "%s".', 'servebolt-wp'), $termName)]);
             }
         } catch (QueueError $e) {
             // TODO: Handle response from queue system

--- a/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
@@ -68,6 +68,19 @@ class WordPressCachePurge
     }
 
     /**
+     * Alias for method "purgeByTermId".
+     *
+     * @param int $termId
+     * @param string $taxonomySlug
+     * @param bool $returnWpError
+     * @return bool
+     */
+    public static function purgeByTerm(int $termId, string $taxonomySlug, bool $returnWpError = false)
+    {
+        return self::purgeByTermId($termId, $taxonomySlug, $returnWpError);
+    }
+
+    /**
      * Alias for method "purgeTermCache".
      *
      * @param int $termId
@@ -91,7 +104,6 @@ class WordPressCachePurge
     {
         return self::purgeByPostId($postId, $returnWpError);
     }
-
 
     /**
      * Alias for method "purgePostCache".


### PR DESCRIPTION
Added feature so that terms can also be cache purged from the WP Admin bar, both when in WP Admin and front-end.