### PR TITLE
WPSO-186 Driver not falling back to default driver when driver not set in options table

### DIFF
--- a/src/Servebolt/CachePurge/CachePurge.php
+++ b/src/Servebolt/CachePurge/CachePurge.php
@@ -237,7 +237,11 @@ class CachePurge
      */
     public static function getSelectedCachePurgeDriver(?int $blogId = null)
     {
-        $value = smartGetOption($blogId, 'cache_purge_driver');
+        $noExistKey = 'value-does-not-exist';
+        $value = smartGetOption($blogId, 'cache_purge_driver', $noExistKey);
+        if ($value === $noExistKey) {
+            $value = self::defaultDriverName();
+        }
         return apply_filters('sb_optimizer_selected_cache_purge_driver', $value);
     }
 


### PR DESCRIPTION
Fixed issue regarding default cache purge driver not being selected whenever driver was not set in options table