### PR TITLE
WPSO-223 Compat: WP Rocket - cache not being properly cleared on sites with multiple domains

### DIFF
--- a/src/Servebolt/Compatibility/WpRocket/DisableWpRocketCache.php
+++ b/src/Servebolt/Compatibility/WpRocket/DisableWpRocketCache.php
@@ -5,6 +5,7 @@ namespace Servebolt\Optimizer\Compatibility\WpRocket;
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 //use Servebolt\Optimizer\AcceleratedDomains\AcceleratedDomains;
+use WP_Filesystem_Direct;
 use Servebolt\Optimizer\FullPageCache\FullPageCacheSettings;
 
 /**
@@ -45,10 +46,48 @@ class DisableWpRocketCache
      */
     public function wpRocketClearAllCache(): bool
     {
+        // Delete the cache folder completely
+        if ($this->deleteWpRocketCacheFolder()) {
+            return true;
+        }
         if (function_exists('rocket_clean_domain')) {
-            // Purge all WP Rocket cache
+            // Purge all WP Rocket cache for current domain
             return rocket_clean_domain();
         }
         return false;
+    }
+
+    /**
+     * Delete the WP Rocket cache folder.
+     *
+     * @return bool
+     */
+    private function deleteWpRocketCacheFolder(): bool
+    {
+        if (!defined('WP_ROCKET_CACHE_ROOT_PATH')) {
+            return false;
+        }
+        $wpRocketCacheFolderPath = WP_ROCKET_CACHE_ROOT_PATH;
+        $filesystem = $this->wpDirectFilesystem();
+        if ($filesystem) {
+            if (!$filesystem->exists($wpRocketCacheFolderPath)) {
+                return true;
+            } elseif ($filesystem->delete($wpRocketCacheFolderPath)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Instanciate the filesystem class
+     *
+     * @return object WP_Filesystem_Direct instance
+     */
+    private function wpDirectFilesystem(): object
+    {
+        require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+        require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+        return new WP_Filesystem_Direct(new \StdClass());
     }
 }

--- a/src/Servebolt/Compatibility/WpRocket/DisableWpRocketCache.php
+++ b/src/Servebolt/Compatibility/WpRocket/DisableWpRocketCache.php
@@ -72,7 +72,7 @@ class DisableWpRocketCache
         if ($filesystem) {
             if (!$filesystem->exists($wpRocketCacheFolderPath)) {
                 return true;
-            } elseif ($filesystem->delete($wpRocketCacheFolderPath)) {
+            } elseif ($filesystem->delete($wpRocketCacheFolderPath, true)) {
                 return true;
             }
         }


### PR DESCRIPTION
Compat: WP Rocket - cache not being properly cleared on sites with multiple domains whenever FPC/ACD is enabled