### PR TITLE
Replace filemtime for static assets

### DIFF
--- a/src/Servebolt/Admin/Assets.php
+++ b/src/Servebolt/Admin/Assets.php
@@ -7,6 +7,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 use Servebolt\Optimizer\Admin\GeneralSettings\GeneralSettings;
 use function Servebolt\Optimizer\Helpers\booleanToString;
 use function Servebolt\Optimizer\Helpers\getAjaxNonce;
+use function Servebolt\Optimizer\Helpers\getCurrentPluginVersion;
+use function Servebolt\Optimizer\Helpers\getVersionForStaticAsset;
 
 /**
  * Class Servebolt_Optimizer_Assets
@@ -175,7 +177,7 @@ class Assets {
      */
     private function enqueueScript($handle, $src, $deps = [], $in_footer = false): void
     {
-        wp_enqueue_script($handle, SERVEBOLT_PLUGIN_DIR_URL . $src, $deps, filemtime(SERVEBOLT_PLUGIN_DIR_PATH . $src), $in_footer);
+        wp_enqueue_script($handle, SERVEBOLT_PLUGIN_DIR_URL . $src, $deps, getVersionForStaticAsset(SERVEBOLT_PLUGIN_DIR_PATH . $src), $in_footer);
     }
 
     /**
@@ -187,7 +189,7 @@ class Assets {
      */
     private function enqueueStyle($handle, $src, $deps = []): void
     {
-        wp_enqueue_style($handle, SERVEBOLT_PLUGIN_DIR_URL . $src, $deps, filemtime(SERVEBOLT_PLUGIN_DIR_PATH . $src));
+        wp_enqueue_style($handle, SERVEBOLT_PLUGIN_DIR_URL . $src, $deps, getVersionForStaticAsset(SERVEBOLT_PLUGIN_DIR_PATH . $src));
     }
 
     /**

--- a/src/Servebolt/Admin/Assets.php
+++ b/src/Servebolt/Admin/Assets.php
@@ -7,7 +7,6 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 use Servebolt\Optimizer\Admin\GeneralSettings\GeneralSettings;
 use function Servebolt\Optimizer\Helpers\booleanToString;
 use function Servebolt\Optimizer\Helpers\getAjaxNonce;
-use function Servebolt\Optimizer\Helpers\getCurrentPluginVersion;
 use function Servebolt\Optimizer\Helpers\getVersionForStaticAsset;
 
 /**

--- a/src/Servebolt/Admin/CachePurgeControl/CachePurgeControl.php
+++ b/src/Servebolt/Admin/CachePurgeControl/CachePurgeControl.php
@@ -13,6 +13,7 @@ use Servebolt\Optimizer\Queue\Queues\WpObjectQueue;
 use Servebolt\Optimizer\Traits\Singleton;
 use function Servebolt\Optimizer\Helpers\getPostTypeSingularName;
 use function Servebolt\Optimizer\Helpers\getTaxonomySingularName;
+use function Servebolt\Optimizer\Helpers\getVersionForStaticAsset;
 use function Servebolt\Optimizer\Helpers\isScreen;
 use function Servebolt\Optimizer\Helpers\view;
 use function Servebolt\Optimizer\Helpers\isHostedAtServebolt;
@@ -268,7 +269,7 @@ class CachePurgeControl
             'servebolt-optimizer-cloudflare-cache-purge-scripts',
             SERVEBOLT_PLUGIN_DIR_URL . 'assets/dist/js/cloudflare-cache-purge.js',
             ['servebolt-optimizer-scripts'],
-            filemtime(SERVEBOLT_PLUGIN_DIR_PATH . 'assets/dist/js/cloudflare-cache-purge.js'),
+            getVersionForStaticAsset(SERVEBOLT_PLUGIN_DIR_PATH . 'assets/dist/js/cloudflare-cache-purge.js'),
             true
         );
     }

--- a/src/Servebolt/Admin/FullPageCacheControl/FullPageCacheControl.php
+++ b/src/Servebolt/Admin/FullPageCacheControl/FullPageCacheControl.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use Servebolt\Optimizer\Admin\FullPageCacheControl\Ajax\FpcPostExclusion;
 use Servebolt\Optimizer\Traits\Singleton;
+use function Servebolt\Optimizer\Helpers\getVersionForStaticAsset;
 use function Servebolt\Optimizer\Helpers\isScreen;
 use function Servebolt\Optimizer\Helpers\view;
 use function Servebolt\Optimizer\Helpers\getServeboltAdminUrl;
@@ -59,7 +60,7 @@ class FullPageCacheControl
         if (!isScreen('servebolt_page_servebolt-fpc')) {
             return;
         }
-        wp_enqueue_script('servebolt-optimizer-fpc-scripts', SERVEBOLT_PLUGIN_DIR_URL . 'assets/dist/js/fpc.js', ['servebolt-optimizer-scripts'], filemtime(SERVEBOLT_PLUGIN_DIR_PATH . 'assets/dist/js/fpc.js'), true );
+        wp_enqueue_script('servebolt-optimizer-fpc-scripts', SERVEBOLT_PLUGIN_DIR_URL . 'assets/dist/js/fpc.js', ['servebolt-optimizer-scripts'], getVersionForStaticAsset(SERVEBOLT_PLUGIN_DIR_PATH . 'assets/dist/js/fpc.js'), true );
     }
 
     /**

--- a/src/Servebolt/Admin/PerformanceChecks/PerformanceChecks.php
+++ b/src/Servebolt/Admin/PerformanceChecks/PerformanceChecks.php
@@ -7,6 +7,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 use Servebolt\Optimizer\DatabaseOptimizer\DatabaseChecks;
 use Servebolt\Optimizer\Admin\PerformanceChecks\Ajax\OptimizeActions;
 use Servebolt\Optimizer\Traits\Singleton;
+use function Servebolt\Optimizer\Helpers\getVersionForStaticAsset;
 use function Servebolt\Optimizer\Helpers\isScreen;
 use function Servebolt\Optimizer\Helpers\view;
 
@@ -49,7 +50,7 @@ class PerformanceChecks
         if (!isScreen('servebolt_page_servebolt-performance-tools')) {
             return;
         }
-        wp_enqueue_script( 'servebolt-optimizer-performance-checks-scripts', SERVEBOLT_PLUGIN_DIR_URL . 'assets/dist/js/performance-checks.js', ['servebolt-optimizer-scripts'], filemtime(SERVEBOLT_PLUGIN_DIR_PATH . 'assets/dist/js/performance-checks.js'), true );
+        wp_enqueue_script( 'servebolt-optimizer-performance-checks-scripts', SERVEBOLT_PLUGIN_DIR_URL . 'assets/dist/js/performance-checks.js', ['servebolt-optimizer-scripts'], getVersionForStaticAsset(SERVEBOLT_PLUGIN_DIR_PATH . 'assets/dist/js/performance-checks.js'), true );
     }
 
     /**

--- a/src/Servebolt/Helpers/Helpers.php
+++ b/src/Servebolt/Helpers/Helpers.php
@@ -905,6 +905,34 @@ function getCurrentPluginVersion(bool $ignoreBetaVersion = true): ?string
 }
 
 /**
+ * Get the version string to use for static assets in the Servebolt plugin.
+ *
+ * @param string $assetSrc
+ *
+ * @return string
+ *
+ * @internal This function is inteded for use in the Servebolt plugin and should not be used by others.
+ */
+function getVersionForStaticAsset(string $assetSrc): string
+{
+    $pluginVersion = getCurrentPluginVersion(false);
+
+    // Fallback to using `filemtime` if we could not resolve the current plugin version
+    if ($pluginVersion === null) {
+        $filemtime = filemtime($assetSrc);
+
+        // If even `filemtime` bails out make sure the asset is cache busted by using the current unix timestamp
+        if ($filemtime === false) {
+            return (string)time();
+        }
+
+        return (string)$filemtime;
+    }
+
+    return $pluginVersion;
+}
+
+/**
  * Require the user to be a super admin.
  */
 function requireSuperadmin()

--- a/src/Servebolt/Helpers/Helpers.php
+++ b/src/Servebolt/Helpers/Helpers.php
@@ -890,11 +890,16 @@ function isDebug(): bool
  */
 function getCurrentPluginVersion(bool $ignoreBetaVersion = true): ?string
 {
-    if(!function_exists('get_plugin_data')) {
-        require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+    static $version = null;
+
+    if ($version === null) {
+        if(!function_exists('get_plugin_data')) {
+            require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+        }
+        $pluginData = get_plugin_data(SERVEBOLT_PLUGIN_FILE);
+        $version = arrayGet('Version', $pluginData);
     }
-    $pluginData = get_plugin_data(SERVEBOLT_PLUGIN_FILE);
-    $version = arrayGet('Version', $pluginData);
+
     if (!$version) {
         return null;
     }


### PR DESCRIPTION
Remove usage of `filemtime` for static assets and replace it by the plugin version (which should be a great cache buster for end-users), since that makes little sense (maybe only for development) so this save a few syscalls.

And also cache the `get_plugin_data()['Version']` result so that multiple calls to the function only parse the plugin data once per request, this is because `get_plugin_data` is quite the beast of a call to do "a lot" now the plugin version number can be used for... cache busting for example 😉 