### PR TITLE
WPSO-266 Single-file based composer packages not included in autoloader due to Mozart namespace prefixing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,9 @@
   "autoload": {
     "files": [
       "src/Servebolt/Helpers/Helpers.php",
-      "src/Servebolt/CachePurge/ThirdPartyFunctions.php"
+      "src/Servebolt/CachePurge/ThirdPartyFunctions.php",
+      "vendor/jakeasmith/http_build_url/src/http_build_url.php",
+      "vendor/ralouphie/getallheaders/src/getallheaders.php"
     ],
     "psr-4": {
       "Servebolt\\Optimizer\\": "src/Servebolt",

--- a/src/Servebolt/Admin/Assets.php
+++ b/src/Servebolt/Admin/Assets.php
@@ -9,14 +9,14 @@ use function Servebolt\Optimizer\Helpers\booleanToString;
 use function Servebolt\Optimizer\Helpers\getAjaxNonce;
 
 /**
- * Class Servebolt_Optimizer_Assets
+ * Class Assets
  *
  * This class includes the CSS and JavaScript of the plugin.
  */
 class Assets {
 
 	/**
-	 * Servebolt_Optimizer_Assets constructor.
+	 * Assets constructor.
 	 */
 	public function __construct()
     {


### PR DESCRIPTION
Fixed composer dependecy issues for packages autoloaded through the 'files'-property in composer.json, corrected typo in comment