### PR TITLE
WPSO-272 Fatal error - SBO 3.0.1 - wp servebolt fpc activate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Phan, PHPCS and PHPLint should be installed by composer.
 You can run the tests with this command: `composer test`
 
 ## Changelog
+#### 3.0.2
+* Fixed bug in compatibility code for older versions of WP Rocket
+
 #### 3.0.1
 * Corrected typo in string “Accelerated domains” to use uppercase in first character of each word.
 * Fixed issue in cache headers - the feature to exclude posts from cache was broken due to wrong order in conditions in the cache header logic. This is now fixed.

--- a/Readme.txt
+++ b/Readme.txt
@@ -93,6 +93,9 @@ Yes, you can. The database optimizations are beneficial for everyone as well as 
 If you're a Servebolt client, please reach out to our Support Team and we'll be happy to help you out there. Alternatively, you can create a support forum request [here](https://wordpress.org/support/plugin/servebolt-optimizer/).
 
 == Changelog ==
+= 3.0.2 =
+* Fixed bug in compatibility code for older versions of WP Rocket
+
 = 3.0.1 =
 * Corrected typo in string “Accelerated domains” to use uppercase in first character of each word.
 * Fixed issue in cache headers - the feature to exclude posts from cache was broken due to wrong order in conditions in the cache header logic. This is now fixed.

--- a/src/Servebolt/Compatibility/WpRocket/DisableWpRocketCache.php
+++ b/src/Servebolt/Compatibility/WpRocket/DisableWpRocketCache.php
@@ -53,7 +53,11 @@ class DisableWpRocketCache
         */
         if (function_exists('rocket_clean_domain')) {
             // Purge all WP Rocket cache for current domain
-            return rocket_clean_domain();
+            $purgeResult = rocket_clean_domain();
+            if (is_bool($purgeResult)) {
+                return $purgeResult;
+            }
+            return true; // We don't really know how the purge went, so unfortunately we have to assume that it went okay
         }
         return false;
     }


### PR DESCRIPTION
Added support for older versions of WP Rocket in compatibility class for cache disabling