### PR TITLE
WPSO-297 Prevent default image quality parameter from being sent unless it has a different value

### DIFF
--- a/src/Servebolt/AcceleratedDomains/ImageResize/ImageResize.php
+++ b/src/Servebolt/AcceleratedDomains/ImageResize/ImageResize.php
@@ -122,10 +122,10 @@ class ImageResize
     /**
      * Set image quality.
      *
-     * @param int $imageQuality
+     * @param null|int $imageQuality
      * @return $this
      */
-    public function setImageQuality(int $imageQuality)
+    public function setImageQuality(?int $imageQuality)
     {
         $this->imageQuality = $imageQuality;
         return $this;
@@ -182,12 +182,15 @@ class ImageResize
      *
      * @return int
      */
-    private function getImageQuality(): int
+    private function getImageQuality():? int
     {
         if (is_int($this->imageQuality)) {
+            if ($this->imageQuality === self::$defaultImageQuality) {
+                return null; // Fallback to default value in ACD Worker
+            }
             return $this->imageQuality;
         }
-        return self::$defaultImageQuality;
+        return null; // Fallback to default value in ACD Worker
     }
 
     /**
@@ -219,11 +222,10 @@ class ImageResize
     private function defaultImageResizeParameters($additionalParams): array
     {
         $additionalParams = apply_filters('sb_optimizer_acd_image_resize_additional_params', $additionalParams);
-        $params = [
-            'quality' => $this->getImageQuality(),
-            //'metadata' => $this->getMetadataOptimizationLevel(),
-            //'format'  => 'auto',
-        ];
+        $params = [];
+        if ($imageQuality = $this->getImageQuality()) {
+            $params['quality'] = $imageQuality;
+        }
         if ($metadata = $this->getMetadataOptimizationLevel()) {
             $params['metadata'] = $metadata;
         }

--- a/tests/Unit/AcceleratedDomainsImageResize/AcceleratedDomainsImageResizeTest.php
+++ b/tests/Unit/AcceleratedDomainsImageResize/AcceleratedDomainsImageResizeTest.php
@@ -50,7 +50,7 @@ class AcceleratedDomainsImageResizeTest extends WP_UnitTestCase
 
     public function testThatImageDimensionsAreAppliedToQueryString()
     {
-        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=800';
+        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=800';
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', 800, 800, false];
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
         $this->assertEquals($expectedUrl, $modifiedAttachmentData[0]);
@@ -60,7 +60,15 @@ class AcceleratedDomainsImageResizeTest extends WP_UnitTestCase
     {
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', 800, 800, false];
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertContains('quality=85', $modifiedAttachmentData[0]);
+        $this->assertNotContains('quality=85', $modifiedAttachmentData[0]);
+
+        $this->ir->setImageQuality(69);
+        $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
+        $this->assertContains('quality=69', $modifiedAttachmentData[0]);
+
+        $this->ir->setImageQuality(null);
+        $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
+        $this->assertNotContains('quality=69', $modifiedAttachmentData[0]);
     }
 
     public function testThatWeCanSetMetadataOptimizationLevels()
@@ -68,31 +76,31 @@ class AcceleratedDomainsImageResizeTest extends WP_UnitTestCase
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', 800, 800, false];
         $this->ir->setMetadataOptimizationLevel('none');
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&metadata=none&width=800', $modifiedAttachmentData[0]);
+        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?metadata=none&width=800', $modifiedAttachmentData[0]);
 
         $this->ir->setMetadataOptimizationLevel('no_metadata');
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&metadata=none&width=800', $modifiedAttachmentData[0]);
+        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?metadata=none&width=800', $modifiedAttachmentData[0]);
 
         $this->ir->setMetadataOptimizationLevel(null);
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=800', $modifiedAttachmentData[0]);
+        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=800', $modifiedAttachmentData[0]);
 
         $this->ir->setMetadataOptimizationLevel('copyright');
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=800', $modifiedAttachmentData[0]);
+        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=800', $modifiedAttachmentData[0]);
 
         $this->ir->setMetadataOptimizationLevel('keep_copyright');
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=800', $modifiedAttachmentData[0]);
+        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=800', $modifiedAttachmentData[0]);
 
         $this->ir->setMetadataOptimizationLevel('keep');
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&metadata=keep&width=800', $modifiedAttachmentData[0]);
+        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?metadata=keep&width=800', $modifiedAttachmentData[0]);
 
         $this->ir->setMetadataOptimizationLevel('keep_all');
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
-        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&metadata=keep&width=800', $modifiedAttachmentData[0]);
+        $this->assertEquals('https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?metadata=keep&width=800', $modifiedAttachmentData[0]);
     }
 
     /*
@@ -113,7 +121,7 @@ class AcceleratedDomainsImageResizeTest extends WP_UnitTestCase
             return 2000;
         });
 
-        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=2000&height=2000';
+        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=2000&height=2000';
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', 2500, 2500, false];
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
         $this->assertEquals($expectedUrl, $modifiedAttachmentData[0]);
@@ -125,19 +133,19 @@ class AcceleratedDomainsImageResizeTest extends WP_UnitTestCase
     public function testThatMaxHeightAndWidthDimensionsGetsApplied()
     {
         // Width and height exceeds the max dimension
-        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=1920&height=1080';
+        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=1920&height=1080';
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', '2000', '2000', false];
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
         $this->assertEquals($expectedUrl, $modifiedAttachmentData[0]);
 
         // Only width exceeds the max dimension
-        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=1920';
+        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=1920';
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', 2000, 1000, false];
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
         $this->assertEquals($expectedUrl, $modifiedAttachmentData[0]);
 
         // Only height exceeds the max dimension
-        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=1000&height=1080';
+        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=1000&height=1080';
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', 1000, 2000, false];
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
         $this->assertEquals($expectedUrl, $modifiedAttachmentData[0]);
@@ -155,7 +163,7 @@ class AcceleratedDomainsImageResizeTest extends WP_UnitTestCase
     public function testThatHeightIsIncludedWhenUsingAFilterOverride()
     {
         add_filter('sb_optimizer_acd_image_resize_force_add_height', '__return_true');
-        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?quality=85&width=1000&height=1000';
+        $expectedUrl = 'https://some-domain.com/acd-cgi/img/v1/wp-content/uploads/woocommerce-placeholder.png?width=1000&height=1000';
         $attachmentData = ['https://some-domain.com/wp-content/uploads/woocommerce-placeholder.png', '1000', '1000', false];
         $modifiedAttachmentData = $this->ir->alterSingleImageUrl($attachmentData);
         $this->assertEquals($expectedUrl, $modifiedAttachmentData[0]);


### PR DESCRIPTION
- Omitted image quality parameter if value is default (85)
- Updated tests