### PR TITLE
WPSO-298 Prevent larger sizes than the max-size to be set in a srcset tag

### DIFF
--- a/src/Servebolt/AcceleratedDomains/ImageResize/WpImageSizeIndex.php
+++ b/src/Servebolt/AcceleratedDomains/ImageResize/WpImageSizeIndex.php
@@ -4,19 +4,22 @@ namespace Servebolt\Optimizer\AcceleratedDomains\ImageResize;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
+use function Servebolt\Optimizer\Helpers\sbCalculateImageSizes;
+
 /**
  * Class WpImageSizeIndex
  * @package Servebolt\Optimizer\AcceleratedDomains\ImageResize
  */
 class WpImageSizeIndex
 {
+
     /**
      * WpImageSizeIndex constructor.
      */
     public function __construct()
     {
         if (apply_filters('sb_optimizer_acd_add_custom_sizes_to_srcset', true)) {
-            add_filter('wp_calculate_image_srcset', [$this, 'addCustomImageSizesToSrcset'], 10, 3);
+            add_filter('wp_calculate_image_srcset', [$this, 'addCustomImageSizesToSrcset'], 10, 5);
         }
     }
 
@@ -24,17 +27,58 @@ class WpImageSizeIndex
      * @param $sources
      * @param $sizeArray
      * @param $imageSrc
+     * @param $imageMeta
+     * @param $attachmentId
      * @return array
      */
-    public function addCustomImageSizesToSrcset($sources, $sizeArray, $imageSrc): array
+    public function addCustomImageSizesToSrcset($sources, $sizeArray, $imageSrc, $imageMeta, $attachmentId): array
     {
+        $width = sbCalculateImageSizes($sizeArray, $imageSrc, $imageMeta, $attachmentId);
         if ($extraSizes = ImageSizeIndexModel::getSizes()) {
             foreach ($extraSizes as $size) {
+                if (apply_filters('sb_optimizer_acd_limit_srcset_width_to_image_width', false) && $this->sizeTooBig($size, $width)) {
+                    continue;
+                }
                 $size['url'] = $imageSrc;
                 $sources[$size['value']] = $size;
             }
         }
+
+        if (apply_filters('sb_optimizer_acd_limit_all_srcset_width_to_image_width', true)) {
+            $sources = $this->limitSizesToImageSize($sources, $width);
+        }
+        
         ksort($sources);
+
         return $sources;
+    }
+
+    /**
+     * Check if the current size is bigger than the image.
+     *
+     * @param array $size
+     * @param int $width
+     * @return bool
+     */
+    private function sizeTooBig(array $size, int $width): bool
+    {
+        if ($size['descriptor'] == 'w' && $size['value'] <= $width) {
+            return false; // Size ok
+        }
+        return true;
+    }
+
+    /**
+     * Limit array of srcset-sizes to the width of the image.
+     *
+     * @param array $sources
+     * @param int $width
+     * @return array
+     */
+    private function limitSizesToImageSize(array $sources, int $width): array
+    {
+        return array_filter($sources, function($size) use ($width) {
+            return !$this->sizeTooBig($size, $width);
+        });
     }
 }

--- a/src/Servebolt/Helpers/Helpers.php
+++ b/src/Servebolt/Helpers/Helpers.php
@@ -1356,6 +1356,48 @@ function wpDirectFilesystem(): object
 }
 
 /**
+ * This is a clone of the function "wp_calculate_image_sizes" in the WP core-files.
+ * @param $size
+ * @param null $image_src
+ * @param null $image_meta
+ * @param int $attachment_id
+ * @return mixed|void
+ */
+function sbCalculateImageSizes( $size, $image_src = null, $image_meta = null, $attachment_id = 0 )
+{
+    $width = 0;
+
+    if (is_array($size)) {
+        $width = absint($size[0]);
+    } elseif (is_string($size)) {
+        if (!$image_meta && $attachment_id) {
+            $image_meta = wp_get_attachment_metadata($attachment_id);
+        }
+
+        if (is_array($image_meta)) {
+            $size_array = _wp_get_image_size_from_meta($size, $image_meta);
+            if ($size_array) {
+                $width = absint($size_array[0]);
+            }
+        }
+    }
+
+    /**
+     * Filters the output of 'sbCalculateImageSizes()'.
+     *
+     * @since 4.4.0
+     *
+     * @param int          $width         The width of the image.
+     * @param string|int[] $size          Requested image size. Can be any registered image size name, or
+     *                                    an array of width and height values in pixels (in that order).
+     * @param string|null  $image_src     The URL to the image file or null.
+     * @param array|null   $image_meta    The image meta data as returned by wp_get_attachment_metadata() or null.
+     * @param int          $attachment_id Image attachment ID of the original image or 0.
+     */
+    return apply_filters( 'sb_calculate_image_sizes', $width, $size, $image_src, $image_meta, $attachment_id );
+}
+
+/**
  * Override an option value.
  *
  * @param string $optionName


### PR DESCRIPTION
Added feature to limit sizes in the srcset-attribute based on the sizes-attribute value