### PR TITLE
WPSO-316 Print a header record for each manifest file

### DIFF
--- a/src/Servebolt/Prefetching/ManifestHeaders.php
+++ b/src/Servebolt/Prefetching/ManifestHeaders.php
@@ -20,7 +20,7 @@ class ManifestHeaders
         }
         if ($headerItems = self::getHeaderItems()) {
             foreach ($headerItems as $headerItem) {
-                header($headerItem);
+                header($headerItem, false);
             }
         }
     }

--- a/src/Servebolt/Prefetching/ManifestHeaders.php
+++ b/src/Servebolt/Prefetching/ManifestHeaders.php
@@ -18,12 +18,27 @@ class ManifestHeaders
         if (headers_sent()) {
             return;
         }
-        if ($files = ManifestFilesModel::get()) {
-            $prefetchFiles = [];
-            foreach ($files as $file) {
-                $prefetchFiles[] = '<' . $file . '>; rel="prefetch"';
+        if ($headerItems = self::getHeaderItems()) {
+            foreach ($headerItems as $headerItem) {
+                header($headerItem);
             }
-            header('Link: ' . implode(', ', $prefetchFiles));
         }
+    }
+
+    /**
+     * Prepare array of headers.
+     *
+     * @return array|null
+     */
+    public static function getHeaderItems(): ?array
+    {
+        if ($files = ManifestFilesModel::get()) {
+            $headerItems = [];
+            foreach ($files as $file) {
+                $headerItems[] = 'Link: <' . $file . '>; rel="prefetch"';
+            }
+            return $headerItems;
+        }
+        return null;
     }
 }

--- a/tests/Unit/Prefetch/ManifestFileWriterTest.php
+++ b/tests/Unit/Prefetch/ManifestFileWriterTest.php
@@ -3,6 +3,7 @@
 namespace Unit\Prefetch;
 
 use Servebolt\Optimizer\Prefetching\ManifestFilesModel;
+use Servebolt\Optimizer\Prefetching\ManifestHeaders;
 use Unit\Traits\MultisiteTrait;
 use ServeboltWPUnitTestCase;
 use Servebolt\Optimizer\Prefetching\ManifestFileWriter;
@@ -172,5 +173,16 @@ class ManifestFileWriterTest extends ServeboltWPUnitTestCase
         $this->setUpManifestDummyData();
         ManifestFileWriter::write();
         $this->assertCount(9, explode(PHP_EOL, file_get_contents($scriptFilePath)));
+    }
+
+    public function testThatHeadersAreSet()
+    {
+        ManifestFileWriter::write();
+        $expected = [
+            'Link: <http://example.org/wp-content/uploads/acd/prefetch/manifest-style.txt>; rel="prefetch"',
+            'Link: <http://example.org/wp-content/uploads/acd/prefetch/manifest-script.txt>; rel="prefetch"',
+            'Link: <http://example.org/wp-content/uploads/acd/prefetch/manifest-menu.txt>; rel="prefetch"',
+        ];
+        $this->assertEquals($expected, ManifestHeaders::getHeaderItems());
     }
 }


### PR DESCRIPTION
Changed so that manifest files are printed to individuall headers instead of one + added manifest header test