### PR TITLE
WPSO-231 Whenever a post/term gets deleted we need to purge cache

### DIFF
--- a/src/Servebolt/CachePurge/CachePurge.php
+++ b/src/Servebolt/CachePurge/CachePurge.php
@@ -353,9 +353,9 @@ class CachePurge
      */
     public static function queueBasedCachePurgeActiveStateOverride(): ?bool
     {
-        if ( self::queueBasedCachePurgeActiveStateIsOverridden() ) {
+        if (self::queueBasedCachePurgeActiveStateIsOverridden()) {
             if (defined('SERVEBOLT_CF_PURGE_CRON')) {
-                return SERVEBOLT_CF_PURGE_CRON;// Legacy
+                return SERVEBOLT_CF_PURGE_CRON; // Legacy
             } else {
                 return SERVEBOLT_QUEUE_BASED_CACHE_PURGE;
             }
@@ -366,12 +366,12 @@ class CachePurge
     /**
      * Check whether the Cron-based cache purger should be active.
      *
-     * @param bool $respectOverride
      * @param int|null $blogId
+     * @param bool $respectOverride
      *
      * @return bool
      */
-    public static function queueBasedCachePurgeIsActive(bool $respectOverride = true, ?int $blogId = null): bool
+    public static function queueBasedCachePurgeIsActive(?int $blogId = null, bool $respectOverride = true): bool
     {
         $activeStateOverride = self::queueBasedCachePurgeActiveStateOverride();
         if ($respectOverride && is_bool($activeStateOverride)) {

--- a/src/Servebolt/CachePurge/PurgeObject/ObjectTypes/Post.php
+++ b/src/Servebolt/CachePurge/PurgeObject/ObjectTypes/Post.php
@@ -147,6 +147,7 @@ class Post extends SharedMethods
     {
         if (has_filter('sb_optimizer_purge_by_post_original_url')) {
             $originalUrl = apply_filters('sb_optimizer_purge_by_post_original_url', null);
+            remove_all_filters('sb_optimizer_purge_by_post_original_url');
             if ($originalUrl && $postPermalink !== $originalUrl) {
                 $this->addUrl($originalUrl);
             }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/PostMethods.php
@@ -50,12 +50,17 @@ trait PostMethods
      */
     public static function purgePostCache(int $postId): bool
     {
+        $shouldPurgeByQueue = self::shouldPurgeByQueue();
 
         // If this is just a revision, don't purge anything.
         if (!$postId || wp_is_post_revision($postId)) {
             return false;
         }
-        if (CachePurgeDriver::queueBasedCachePurgeIsActive()) {
+
+        do_action('sb_optimizer_purged_post_cache', $postId);
+        do_action('sb_optimizer_purged_post_cache_for_' . $postId);
+
+        if ($shouldPurgeByQueue) {
             $queueInstance = WpObjectQueue::getInstance();
             $queueItemData = [
                 'type' => 'post',
@@ -63,6 +68,7 @@ trait PostMethods
             ];
             if (has_filter('sb_optimizer_purge_by_post_original_url')) {
                 $originalUrl = apply_filters('sb_optimizer_purge_by_post_original_url', null);
+                remove_all_filters('sb_optimizer_purge_by_post_original_url');
                 if ($originalUrl && get_permalink($postId) !== $originalUrl) {
                     $queueItemData['original_url'] = $originalUrl;
                 }

--- a/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
@@ -53,7 +53,10 @@ trait TermMethods
      */
     public static function purgeTermCache(int $termId, string $taxonomySlug): bool
     {
-        if (CachePurgeDriver::queueBasedCachePurgeIsActive()) {
+        do_action('sb_optimizer_purged_term_cache', $termId);
+        do_action('sb_optimizer_purged_term_cache_for_' . $termId);
+
+        if (self::shouldPurgeByQueue()) {
             $queueInstance = WpObjectQueue::getInstance();
             return isQueueItem($queueInstance->add([
                 'type' => 'term',

--- a/src/Servebolt/CachePurge/WpCachePurge.php
+++ b/src/Servebolt/CachePurge/WpCachePurge.php
@@ -32,7 +32,7 @@ class WpCachePurge
             || isTesting()
         ) {
             // Register cache purge event for various hooks
-            new WpObjectCachePurgeActions;
+            WpObjectCachePurgeActions::on();
         }
     }
 

--- a/src/Servebolt/CachePurge/WpObjectCachePurgeActions/ContentChangeTrigger.php
+++ b/src/Servebolt/CachePurge/WpObjectCachePurgeActions/ContentChangeTrigger.php
@@ -6,8 +6,8 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
 use Servebolt\Optimizer\CachePurge\CachePurge;
-use Servebolt\Optimizer\Traits\Singleton;
 use Exception;
+use Servebolt\Optimizer\Traits\Singleton;
 
 /**
  * Class CachePurgeWPActions
@@ -18,18 +18,30 @@ class ContentChangeTrigger
 {
     use Singleton;
 
-    /**
-     * CachePurgeWPActions constructor.
-     */
-    public function __construct()
+    public static function on(): void
     {
-        $this->registerPurgeActions();
+        $instance = self::getInstance();
+        $instance->registerEvents();
+    }
+
+    public static function off(): void
+    {
+        $instance = self::getInstance();
+        $instance->deregisterEvents();
+    }
+
+    public function deregisterEvents(): void
+    {
+        remove_action('edit_term', [$this, 'purgeTermOnSave'], 99, 3);
+        remove_action('save_post', [$this, 'purgePostOnSave'], 99, 3);
+        remove_action('comment_post', [$this, 'purgePostOnCommentPost'], 99, 3);
+        remove_action('transition_comment_status', [$this, 'purgePostOnCommentApproval'], 99, 3);
     }
 
     /**
      * Register action hooks.
      */
-    public function registerPurgeActions()
+    public function registerEvents()
     {
 
         // Skip this feature if automatic cache purge is inactive
@@ -37,9 +49,14 @@ class ContentChangeTrigger
             return;
         }
 
-        // Should skip all automatic cache purge?
+        // Should skip all automatic cache purge on content update?
         if (apply_filters('sb_optimizer_disable_automatic_purge', false)) {
             return;
+        }
+
+        // Purge post when term is edited (Work in progress)
+        if (apply_filters('sb_optimizer_automatic_purge_on_term_save', true)) {
+            add_action('edit_term', [$this, 'purgeTermOnSave'], 99, 3);
         }
 
         // Purge post on post update
@@ -55,11 +72,6 @@ class ContentChangeTrigger
         // Purge post when comment is approved
         if (apply_filters('sb_optimizer_automatic_purge_on_comment_approval', true)) {
             add_action('transition_comment_status', [$this, 'purgePostOnCommentApproval'], 99, 3);
-        }
-
-        // Purge post when term is edited (Work in progress)
-        if (apply_filters('sb_optimizer_automatic_purge_on_term_save', true)) {
-            add_action('edit_term', [$this, 'purgeTermOnSave'], 99, 3);
         }
     }
 

--- a/src/Servebolt/CachePurge/WpObjectCachePurgeActions/DeletionCacheTrigger.php
+++ b/src/Servebolt/CachePurge/WpObjectCachePurgeActions/DeletionCacheTrigger.php
@@ -7,6 +7,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 use Servebolt\Optimizer\CachePurge\CachePurge;
 use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
 use Servebolt\Optimizer\Traits\Singleton;
+use function Servebolt\Optimizer\Helpers\getTaxonomyFromTermId;
 
 /**
  * Class DeletionCacheTrigger
@@ -16,43 +17,79 @@ class DeletionCacheTrigger
 {
     use Singleton;
 
-    /**
-     * DeletionCacheTrigger constructor.
-     */
-    public function __construct()
+    public static function on(): void
+    {
+        $instance = self::getInstance();
+        $instance->registerEvents();
+    }
+
+    public static function off(): void
+    {
+        $instance = self::getInstance();
+        $instance->deregisterEvents();
+    }
+
+    public function deregisterEvents(): void
+    {
+        remove_action('delete_term_taxonomy', [$this, 'deleteTerm'], 10, 1);
+        remove_action('delete_attachment', [$this, 'deletePost'], 10, 1);
+        remove_action('wp_trash_post', [$this, 'deletePost'], 10, 1);
+        remove_action('before_delete_post', [$this, 'deletePost'], 10, 1);
+    }
+
+    public function registerEvents()
     {
         // Skip this feature if automatic cache purge for deletion is inactive
         if (!CachePurge::automaticCachePurgeOnDeletionIsActive()) {
             return;
         }
 
+        // TODO: Handle post transitions too?
+
         // Purge on term delete
         if (apply_filters('sb_optimizer_automatic_purge_on_term_delete', true)) {
-            // TODO: Find term deletion action
+            add_action('delete_term_taxonomy', [$this, 'deleteTerm'], 10, 1);
         }
 
         // Purge on attachment delete
         if (apply_filters('sb_optimizer_automatic_purge_on_attachment_delete', true)) {
-                //add_action('pre_delete_attachment');
+            add_action('delete_attachment', [$this, 'deletePost'], 10, 1);
+        }
+
+        // Purge on post trash
+        if (apply_filters('sb_optimizer_automatic_purge_on_post_trash', true)) {
+            add_action('wp_trash_post', [$this, 'deletePost'], 10, 1);
         }
 
         // Purge on post delete
         if (apply_filters('sb_optimizer_automatic_purge_on_post_delete', true)) {
-
-            // Post gets trashed
-            add_action('wp_trash_post', [$this, 'postDeleted'], 10, 1);
-
-            // Post gets deleted
-            add_action('before_delete_post', [$this, 'postDeleted'], 10, 1);
+            add_action('before_delete_post', [$this, 'deletePost'], 10, 1);
         }
     }
 
     /**
+     * Callback for just before a term gets deleted.
+     *
+     * @param int $termId
+     */
+    public function deleteTerm(int $termId): void
+    {
+        $taxonomySlug = (getTaxonomyFromTermId($termId))->name;
+        try {
+            WordPressCachePurge::skipQueueOnce();
+            WordPressCachePurge::purgeByTermId($termId, $taxonomySlug);
+        } catch (Exception $e) {}
+    }
+
+    /**
+     * Callback for just before a post gets deleted.
+     *
      * @param int $postId
      */
-    public function postDeleted(int $postId): void
+    public function deletePost(int $postId): void
     {
         try {
+            WordPressCachePurge::skipQueueOnce();
             WordPressCachePurge::purgeByPostId($postId);
         } catch (Exception $e) {}
     }

--- a/src/Servebolt/CachePurge/WpObjectCachePurgeActions/SlugChangeTrigger.php
+++ b/src/Servebolt/CachePurge/WpObjectCachePurgeActions/SlugChangeTrigger.php
@@ -6,8 +6,8 @@ if (!defined( 'ABSPATH')) exit; // Exit if accessed directly
 
 use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
 use Servebolt\Optimizer\CachePurge\CachePurge;
-use Servebolt\Optimizer\Traits\Singleton;
 use Exception;
+use Servebolt\Optimizer\Traits\Singleton;
 
 /**
  * Class SlugChangeTrigger
@@ -23,18 +23,29 @@ class SlugChangeTrigger
      */
     private $previousPostPermalink = null;
 
-    /**
-     * SlugChangeTrigger constructor.
-     */
-    public function __construct()
+    public static function on(): void
     {
-        $this->registerPurgeActions();
+        $instance = self::getInstance();
+        $instance->registerEvents();
+    }
+
+    public static function off(): void
+    {
+        $instance = self::getInstance();
+        $instance->deregisterEvents();
+    }
+
+    public function deregisterEvents(): void
+    {
+        remove_filter('wp_update_term_data', [$this, 'checkPreviousTermPermalink'], 10, 3);
+        remove_action('pre_post_update', [$this, 'recordPostPermalink'], 99, 1);
+        remove_action('post_updated', [$this, 'checkPreviousPostPermalink'], 99, 1);
     }
 
     /**
      * Register action hooks.
      */
-    private function registerPurgeActions()
+    public function registerEvents()
     {
 
         // Skip this feature if automatic cache purge on slug change is inactive

--- a/src/Servebolt/CachePurge/WpObjectCachePurgeActions/WpObjectCachePurgeActions.php
+++ b/src/Servebolt/CachePurge/WpObjectCachePurgeActions/WpObjectCachePurgeActions.php
@@ -3,6 +3,7 @@
 namespace Servebolt\Optimizer\CachePurge\WpObjectCachePurgeActions;
 
 use Servebolt\Optimizer\CachePurge\CachePurge;
+use Servebolt\Optimizer\Traits\Singleton;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
@@ -12,18 +13,36 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
  */
 class WpObjectCachePurgeActions
 {
-    /**
-     * WpObjectCachePurgeActions constructor.
-     */
-    public function __construct()
+    public static function on(): bool
     {
         // Skip this feature if the cache purge feature is inactive or insufficiently configured
         if (!CachePurge::featureIsAvailable()) {
-            return;
+            return  false;
         }
 
-        ContentChangeTrigger::getInstance();
-        SlugChangeTrigger::getInstance();
-        DeletionCacheTrigger::getInstance();
+        ContentChangeTrigger::on();
+        SlugChangeTrigger::on();
+        DeletionCacheTrigger::on();
+
+        return true;
+    }
+
+    public static function off(): void
+    {
+        ContentChangeTrigger::off();
+        SlugChangeTrigger::off();
+        DeletionCacheTrigger::off();
+    }
+
+    public static function reloadEvents(): void
+    {
+        ContentChangeTrigger::off();
+        ContentChangeTrigger::on();
+
+        SlugChangeTrigger::off();
+        SlugChangeTrigger::on();
+
+        DeletionCacheTrigger::off();
+        DeletionCacheTrigger::on();
     }
 }

--- a/src/Servebolt/FullPageCache/FullPageCache.php
+++ b/src/Servebolt/FullPageCache/FullPageCache.php
@@ -7,8 +7,6 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 use Servebolt\Optimizer\CachePurge\CachePurge;
 use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
 use Servebolt\Optimizer\Traits\Singleton;
-use function Servebolt\Optimizer\Helpers\checkboxIsChecked;
-use function Servebolt\Optimizer\Helpers\smartGetOption;
 
 /**
  * Class FullPageCache
@@ -23,7 +21,7 @@ class FullPageCache
      */
     public function __construct()
     {
-        new FullPageCacheSettings;
+        FullPageCacheSettings::init();
         FullPageCacheHeaders::init();
         $this->purgePostCacheIfAddedToFpcExclusion();
     }
@@ -33,8 +31,9 @@ class FullPageCache
      */
     private function purgePostCacheIfAddedToFpcExclusion(): void
     {
+
         // Skip this feature if the cache purge feature is inactive or insufficiently configured, or it automatic cache purge is inactive
-        if (!CachePurge::featureIsAvailable() || !CachePurge::automaticCachePurgeOnContentUpdateIsActive()) {
+        if (!CachePurge::featureIsAvailable()) {
             return;
         }
 
@@ -47,6 +46,6 @@ class FullPageCache
             try {
                 WordPressCachePurge::purgeByPostId($postId);
             } catch (Exception $e) {}
-        });
+        }, 10, 1);
     }
 }

--- a/src/Servebolt/FullPageCache/FullPageCacheSettings.php
+++ b/src/Servebolt/FullPageCache/FullPageCacheSettings.php
@@ -4,8 +4,8 @@ namespace Servebolt\Optimizer\FullPageCache;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
+use Servebolt\Optimizer\Traits\Singleton;
 use function Servebolt\Optimizer\Helpers\checkboxIsChecked;
-use function Servebolt\Optimizer\Helpers\getOptionName;
 use function Servebolt\Optimizer\Helpers\listenForCheckboxOptionChange;
 use function Servebolt\Optimizer\Helpers\smartGetOption;
 use function Servebolt\Optimizer\Helpers\smartUpdateOption;
@@ -16,6 +16,15 @@ use function Servebolt\Optimizer\Helpers\smartUpdateOption;
  */
 class FullPageCacheSettings
 {
+    use Singleton;
+
+    /**
+     * Alias for "getInstance".
+     */
+    public static function init(): void
+    {
+        self::getInstance();
+    }
 
     /**
      * FullPageCacheSettings constructor.

--- a/src/Servebolt/Helpers/Helpers.php
+++ b/src/Servebolt/Helpers/Helpers.php
@@ -333,18 +333,47 @@ function cacheCookieCheck(): void
 }
 
 /**
- * Get taxonomy singular name by term.
+ * Get taxonomy object by term Id.
+ *
+ * @param int $termId
+ * @return object|null
+ */
+function getTaxonomyFromTermId(int $termId): ?object
+{
+    if ($term = get_term($termId)) {
+        if ($taxonomyObject = get_taxonomy($term->taxonomy)) {
+            return $taxonomyObject;
+        }
+    }
+    return null;
+}
+
+/**
+ * Get for filter/actions on hook.
+ *
+ * @param string|null $hook
+ * @return object|null
+ */
+function getFiltersForHook(?string $hook = null): ?object
+{
+    global $wp_filter;
+    if (empty($hook) || !isset($wp_filter[$hook])) {
+        return null;
+    }
+    return $wp_filter[$hook];
+}
+
+/**
+ * Get taxonomy singular name by term Id.
  *
  * @param int $termId
  * @return string
  */
 function getTaxonomySingularName(int $termId): string
 {
-    if ($term = get_term($termId)) {
-        if ($taxonomyObject = get_taxonomy($term->taxonomy)) {
-            if (isset($taxonomyObject->labels->singular_name) && $taxonomyObject->labels->singular_name) {
-                return mb_strtolower($taxonomyObject->labels->singular_name);
-            }
+    if ($taxonomyObject = getTaxonomyFromTermId($termId)) {
+        if (isset($taxonomyObject->labels->singular_name) && $taxonomyObject->labels->singular_name) {
+            return mb_strtolower($taxonomyObject->labels->singular_name);
         }
     }
     return 'term';

--- a/src/Servebolt/WpCron/Events/MinuteEvent.php
+++ b/src/Servebolt/WpCron/Events/MinuteEvent.php
@@ -5,6 +5,7 @@ namespace Servebolt\Optimizer\WpCron\Events;
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use Servebolt\Optimizer\CachePurge\CachePurge;
+use function Servebolt\Optimizer\Helpers\getFiltersForHook;
 
 /**
  * Class MinuteEvent
@@ -36,28 +37,13 @@ class MinuteEvent
     }
 
     /**
-     * Get for filter/actions on hook.
-     *
-     * @param string|null $hook
-     * @return object|null
-     */
-    private function getFiltersForHook(?string $hook = null): ?object
-    {
-        global $wp_filter;
-        if (empty($hook) || !isset($wp_filter[$hook])) {
-            return null;
-        }
-        return $wp_filter[$hook];
-    }
-
-    /**
      * Check whether we have any actions registered on the hook/action for this event.
      *
      * @return bool
      */
     private function hasActionsRegistered(): bool
     {
-        return !empty($this->getFiltersForHook(self::$hook));
+        return !empty(getFiltersForHook(self::$hook));
     }
 
     /**

--- a/tests/Unit/CachePurgeTriggerTest.php
+++ b/tests/Unit/CachePurgeTriggerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Unit;
+
+use Servebolt\Optimizer\CachePurge\WpObjectCachePurgeActions\WpObjectCachePurgeActions;
+use Servebolt\Optimizer\Utils\DatabaseMigration\MigrationRunner;
+use ServeboltWPUnitTestCase;
+use Unit\Traits\CachePurgeTestTrait;
+
+class CachePurgeTriggerTest extends ServeboltWPUnitTestCase
+{
+    use CachePurgeTestTrait;
+
+    public function setUp()
+    {
+        parent::setUp();
+        MigrationRunner::run(true);
+        $this->setUpBogusAcdConfig();
+        $this->useQueueBasedCachePurge();
+        add_filter('sb_optimizer_automatic_purge_on_post_save', '__return_false'); // Prevent post creation from adding the post to the cache purge queue
+        WpObjectCachePurgeActions::reloadEvents();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        remove_filter('sb_optimizer_automatic_purge_on_post_save', '__return_false');
+    }
+
+    public function testThatTrashingAPostPurgesCache()
+    {
+        $postId = $this->factory()->post->create();
+        $actionCount = did_action('wp_trash_post');
+        wp_delete_post($postId);
+        $this->assertEquals($actionCount + 1, did_action('wp_trash_post'));
+        $this->assertEquals(1, did_action('sb_optimizer_purged_post_cache_for_' . $postId));
+    }
+
+    public function testThatDeletingAPostAPostPurgesCache()
+    {
+        $postId = $this->factory()->post->create();
+        $actionCount = did_action('before_delete_post');
+        wp_delete_post($postId, true);
+        $this->assertEquals($actionCount + 1, did_action('before_delete_post'));
+        $this->assertEquals(1, did_action('sb_optimizer_purged_post_cache_for_' . $postId));
+    }
+}

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -20,8 +20,11 @@ use function Servebolt\Optimizer\Helpers\deleteSiteOption;
 use function Servebolt\Optimizer\Helpers\getAllOptionsNames;
 use function Servebolt\Optimizer\Helpers\getBlogOption;
 use function Servebolt\Optimizer\Helpers\getCurrentPluginVersion;
+use function Servebolt\Optimizer\Helpers\getFiltersForHook;
 use function Servebolt\Optimizer\Helpers\getOption;
 use function Servebolt\Optimizer\Helpers\getSiteOption;
+use function Servebolt\Optimizer\Helpers\getTaxonomyFromTermId;
+use function Servebolt\Optimizer\Helpers\getTaxonomySingularName;
 use function Servebolt\Optimizer\Helpers\iterateSites;
 use function Servebolt\Optimizer\Helpers\javascriptRedirect;
 use function Servebolt\Optimizer\Helpers\listenForCheckboxOptionChange;
@@ -514,11 +517,16 @@ class HelpersTest extends ServeboltWPUnitTestCase
         iterateSites(function ($site) use ($allOptionsNames) {
             foreach ($allOptionsNames as $option) {
                 $value = getBlogOption($site->blog_id, $option);
+                //var_dump($option);
+                //var_dump($value);
                 switch ($option) {
                     // Default options
                     case 'prefetch_file_style_switch':
                     case 'prefetch_file_script_switch':
                     case 'prefetch_file_menu_switch':
+                    case 'cache_purge_auto':
+                    case 'cache_purge_auto_on_slug_change':
+                    case 'cache_purge_auto_on_deletion':
                         $this->assertTrue($value);
                         break;
                     default:
@@ -723,5 +731,26 @@ class HelpersTest extends ServeboltWPUnitTestCase
         ob_end_clean();
         $expected = '<script> window.location = "' . $url . '"; </script>';
         $this->assertEquals($expected, trim($output));
+    }
+
+    public function testThatWeCanGetTaxonomySlug()
+    {
+        $taxonomyObject = getTaxonomyFromTermId(1);
+        $this->assertEquals('category', $taxonomyObject->name);
+    }
+
+    public function testThatWeCanGetTaxonomySingularName()
+    {
+        $this->assertEquals('category', getTaxonomySingularName(1));
+    }
+
+    public function testThatWeCanGetFiltersByHook()
+    {
+        $hookName = 'some-custom-hook';
+        $this->assertNull(getFiltersForHook($hookName));
+        add_filter($hookName, '__return_true');
+        $this->assertIsObject(getFiltersForHook($hookName));
+        remove_filter($hookName, '__return_true');
+        $this->assertNull(getFiltersForHook($hookName));
     }
 }

--- a/tests/Unit/PurgeUrlsCountConstraintTest.php
+++ b/tests/Unit/PurgeUrlsCountConstraintTest.php
@@ -5,6 +5,7 @@ namespace Unit;
 use Servebolt\Optimizer\CachePurge\CachePurge;
 use ServeboltWPUnitTestCase;
 use Servebolt\Optimizer\CachePurge\WordPressCachePurge\PostMethods;
+use Unit\Traits\CachePurgeTestTrait;
 use function Servebolt\Optimizer\Helpers\updateOption;
 
 /**
@@ -13,7 +14,7 @@ use function Servebolt\Optimizer\Helpers\updateOption;
  */
 class PurgeUrlsCountConstraintTest extends ServeboltWPUnitTestCase
 {
-    use PostMethods;
+    use PostMethods, CachePurgeTestTrait;
 
     public function tearDown()
     {
@@ -26,16 +27,6 @@ class PurgeUrlsCountConstraintTest extends ServeboltWPUnitTestCase
         parent::setUp();
         $this->set_permalink_structure('/%postname%/');
         add_filter('sb_optimizer_is_hosted_at_servebolt', '__return_true');
-    }
-
-    private function setUpBogusAcdConfig(): void
-    {
-        add_filter('sb_optimizer_selected_cache_purge_driver', function() {
-            return 'acd';
-        });
-        add_filter('sb_optimizer_acd_is_configured', '__return_true');
-        updateOption('cache_purge_switch', true);
-        updateOption('cache_purge_auto', true);
     }
 
     public function testThatTheNumberOfUrlsGetsRestrictedFromCloudflareDriver()

--- a/tests/Unit/Traits/CachePurgeTestTrait.php
+++ b/tests/Unit/Traits/CachePurgeTestTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Unit\Traits;
+
+use function Servebolt\Optimizer\Helpers\updateOption;
+
+/**
+ * Trait CachePurgeTestTrait
+ * @package Unit
+ */
+trait CachePurgeTestTrait
+{
+    /**
+     * Set up bogus ACD config.
+     */
+    private function setUpBogusAcdConfig(): void
+    {
+        add_filter('sb_optimizer_selected_cache_purge_driver', function() {
+            return 'acd';
+        });
+        add_filter('sb_optimizer_acd_is_configured', '__return_true');
+        updateOption('cache_purge_switch', true);
+        updateOption('cache_purge_auto', true);
+    }
+
+    /**
+     * Use the queue based cache purge.
+     */
+    private function useQueueBasedCachePurge(): void
+    {
+        add_filter('sb_optimizer_get_option_servebolt_queue_based_cache_purge', '__return_true');
+    }
+}

--- a/tests/Unit/UrlQueueTest.php
+++ b/tests/Unit/UrlQueueTest.php
@@ -4,6 +4,7 @@ namespace Unit;
 
 use Servebolt\Optimizer\Queue\Queues\UrlQueue;
 use ServeboltWPUnitTestCase;
+use Unit\Traits\CachePurgeTestTrait;
 use function Servebolt\Optimizer\Helpers\updateOption;
 
 /**
@@ -12,6 +13,8 @@ use function Servebolt\Optimizer\Helpers\updateOption;
  */
 class UrlQueueTest extends ServeboltWPUnitTestCase
 {
+    use CachePurgeTestTrait;
+
     public function tearDown()
     {
         parent::tearDown();
@@ -22,16 +25,6 @@ class UrlQueueTest extends ServeboltWPUnitTestCase
     {
         parent::setUp();
         add_filter('sb_optimizer_is_hosted_at_servebolt', '__return_true');
-    }
-
-    private function setUpBogusAcdConfig(): void
-    {
-        add_filter('sb_optimizer_selected_cache_purge_driver', function() {
-            return 'acd';
-        });
-        add_filter('sb_optimizer_acd_is_configured', '__return_true');
-        updateOption('cache_purge_switch', true);
-        updateOption('cache_purge_auto', true);
     }
 
     public function testThatUrlChunkSizeIsSetAccordingToDriver()


### PR DESCRIPTION
- Moved function 'getFiltersForHook' to to helper file + added test
- Created cache purge test trait for shared methods when testing the cache purge feature
- Fixed issue with test 'testThatPostGetsCachePurgedWhenAddedToFpcExclusion'
- Added tests for automatic cache purge trigger
- Added feature to bypass cache purge queue using static method 'skipQueue' and 'skipQueueOnce'
- Added helper function 'getTaxonomyFromTermId' and implemented it in 'getTaxonomySingularName' + added tests
- Made automatic cache purge events into a 'reloadable' structure
- Fixed potential bug in cache purge feature related to the filter 'sb_optimizer_purge_by_post_original_url'
- Added cache purge actions 'sb_optimizer_purged_term_cache' and 'sb_optimizer_purged_post_cache'