### PR TITLE
WPSO-323 Compat: Force disable Jetpack Site Accelerator when Accelerated Domains is active

### DIFF
--- a/src/Servebolt/Compatibility/Compatibility.php
+++ b/src/Servebolt/Compatibility/Compatibility.php
@@ -8,6 +8,7 @@ use Servebolt\Optimizer\Compatibility\Cloudflare\Cloudflare as CloudflareCompati
 use Servebolt\Optimizer\Compatibility\WooCommerce\WooCommerce as WooCommerceCompatibility;
 use Servebolt\Optimizer\Compatibility\WpRocket\WpRocket as WpRocketCompatibility;
 use Servebolt\Optimizer\Compatibility\YoastPremium\YoastPremium as YoastPremiumCompatibility;
+use Servebolt\Optimizer\Compatibility\Jetpack\Jetpack as JetpackCompatibility;
 
 /**
  * Class Compatibility
@@ -24,5 +25,6 @@ class Compatibility
         new WpRocketCompatibility;
         new CloudflareCompatibility;
         new YoastPremiumCompatibility;
+        new JetpackCompatibility;
     }
 }

--- a/src/Servebolt/Compatibility/Jetpack/DisableSiteAcceleratorOnAcd.php
+++ b/src/Servebolt/Compatibility/Jetpack/DisableSiteAcceleratorOnAcd.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Servebolt\Optimizer\Compatibility\Jetpack;
+
+use Servebolt\Optimizer\AcceleratedDomains\AcceleratedDomains;
+use Servebolt\Optimizer\AcceleratedDomains\ImageResize\AcceleratedDomainsImageResize;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+/**
+ * Class DisableSiteAcceleratorOnAcd
+ * @package Servebolt\Optimizer\Compatibility\Jetpack
+ */
+class DisableSiteAcceleratorOnAcd
+{
+    /**
+     * DisableSiteAcceleratorOnAcd constructor.
+     */
+    public function __construct()
+    {
+        if (AcceleratedDomains::isActive() || AcceleratedDomainsImageResize::isActive()) {
+            add_filter('option_jetpack_active_modules', [$this, 'disablePhotonAkaSiteAccelerator']);
+        }
+    }
+
+    /**
+     * Force Jetpack Site Accelerator disabled.
+     *
+     * @param $activeModules
+     * @return mixed|array
+     */
+    function disablePhotonAkaSiteAccelerator($activeModules)
+    {
+        $forcedDisabledModules = ['photon-cdn'];
+        if (is_array($activeModules)) {
+            $activeModules = array_filter($activeModules, function($activeModule) use ($forcedDisabledModules) {
+                return !in_array($activeModule, $forcedDisabledModules);
+            });
+        }
+        return $activeModules;
+    }
+}

--- a/src/Servebolt/Compatibility/Jetpack/Jetpack.php
+++ b/src/Servebolt/Compatibility/Jetpack/Jetpack.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Servebolt\Optimizer\Compatibility\Jetpack;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+use function Servebolt\Optimizer\Helpers\jetpackIsActive;
+
+/**
+ * Class Jetpack
+ * @package Servebolt\Optimizer\Compatibility\Jetpack
+ */
+class Jetpack
+{
+    /**
+     * WooCommerce constructor.
+     */
+    public function __construct()
+    {
+        if (!apply_filters('sb_optimizer_jetpack_compatibility', true)) {
+            return;
+        }
+        if (!jetpackIsActive()) {
+            return;
+        }
+        new DisableSiteAcceleratorOnAcd;
+    }
+}

--- a/src/Servebolt/Helpers/Helpers.php
+++ b/src/Servebolt/Helpers/Helpers.php
@@ -1398,6 +1398,19 @@ function yoastSeoPremiumIsActive(): bool
 }
 
 /**
+ * Check whether plugin Jetpack is active.
+ *
+ * @return bool
+ */
+function jetpackIsActive(): bool
+{
+    if (!function_exists('is_plugin_active')) {
+        require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+    }
+    return is_plugin_active('jetpack/jetpack.php');
+}
+
+/**
  * Instantiate the filesystem class
  *
  * @param bool $ensureConstantsAreSet


### PR DESCRIPTION
Added compat-feature to disabled Jetpack Site Accelerator (formerly Photon CDN) whenever ACD or ACD Image Resizing is active