### PR TITLE
WPSO-360 Image Resize alterSingleImageUrl bug

### DIFF
--- a/src/Servebolt/AcceleratedDomains/ImageResize/ImageResize.php
+++ b/src/Servebolt/AcceleratedDomains/ImageResize/ImageResize.php
@@ -180,11 +180,12 @@ class ImageResize
      * Alter image src-attribute.
      *
      * @param array $image
-     * @param int|null $attachmentId
+     * @param int|string|null $attachmentId
      * @return mixed
      */
-    public function alterSingleImageUrl($image, ?int $attachmentId = null)
+    public function alterSingleImageUrl($image, $attachmentId = null)
     {
+        $attachmentId = (int) $attachmentId;
         if ($attachmentId && !$this->shouldTouchImage($attachmentId)) {
             return $image;
         }


### PR DESCRIPTION
Removed type declaration for filter 'wp_get_attachment_image_src' and switched to type casting instead to handle incorrect setups where attachment IDs are specified as strings