### PR TITLE
WPSO-477 Create access check using JavaScript (instead of in PHP)

### DIFF
--- a/assets/src/js/acd-control.js
+++ b/assets/src/js/acd-control.js
@@ -1,6 +1,49 @@
 document.addEventListener('DOMContentLoaded', function() {
-   document.getElementById('sb-acd-purge-all-cache').addEventListener('click', window.acdPurgeAll);
+   if (element = document.querySelector('#sb-acd-purge-all-cache')) {
+      element.addEventListener('click', window.acdPurgeAll);
+   }
+   if (document.querySelector('form#sb-accelerated-domains-image-resize-options-page-form')) {
+      window.acdImageResizeAccessCheck();
+   }
 });
+
+/**
+ * Check if the current site has access to the Accelerated Domains Image Resize-feature.
+ */
+window.acdImageResizeAccessCheck = function () {
+   window.envConfig.get('sb_acd_image_resize').then(function(result) {
+      if (result) {
+         window.acdImageResizeActivate();
+      } else {
+         window.ensureAcdImageResizeDisabled();
+      }
+   });
+};
+
+/**
+ * Disable the Accelerated Domains Image Resize-feature
+ */
+window.ensureAcdImageResizeDisabled = function () {
+   var element = document.getElementById('acd_image_resize_switch');
+   if (!element.checked) {
+      return;
+   }
+   element.checked = false;
+   const data = new FormData();
+   data.append('action', 'servebolt_acd_image_resize_disable');
+   data.append('security', sb_ajax_object.ajax_nonce);
+   fetch(sb_ajax_object.ajaxurl, {
+       method: 'POST',
+       body: data
+    });
+};
+
+/**
+ * Activate the option to enable/disable the Accelerated Domains Image Resize-feature.
+ */
+window.acdImageResizeActivate = function () {
+   document.getElementById('acd_image_resize_switch').disabled = false;
+};
 
 /**
  * Execute AJAX request to purge all cache.

--- a/assets/src/js/env-config.js
+++ b/assets/src/js/env-config.js
@@ -1,0 +1,88 @@
+/**
+ * Environment config retrieval class.
+ * 
+ * @type {{retrieveConfig: ((function(): Promise<Object|boolean|*>)|*), workerSuffix: string, useDummyData: boolean, defaultValue: null, get: ((function(*=): Promise<*|null>)|*), dummyData: (function(): {sb_acd_worker_3pp_proxy: boolean, sb_acd_image_resize: boolean, sb_acd_worker_google_fonts: boolean}), getSiteUrl: (function(): *), getConfigUrl: (function())}}
+ */
+window.envConfig = {
+
+    /**
+     * The default value if the property is not set in the environment configuration object.
+     */
+    defaultValue: null,
+
+    /**
+     * Whether to use dummy data or not.
+     */
+    useDummyData: false,
+
+    /**
+     * The suffix to be added to the site URL to retrieve the environment configuration.
+     */
+    workerSuffix: '/acd-cgi/config',
+
+    /**
+     * Get an item from the environment configuration object.
+     *
+     * @param key
+     * @returns {Promise<null|*>}
+     */
+    get: async function (key) {
+        var configObject = await this.retrieveConfig();
+        if (!configObject || typeof configObject !== 'object') {
+            return null; // Could not retrieve config
+        }
+        if (!configObject.hasOwnProperty(key)) {
+            return this.defaultValue; // Property not set
+        }
+        return configObject[key];
+    },
+
+    /**
+     * Get site URL.
+     *
+     * @returns {Promise<*>}
+     */
+    getSiteUrl: async function () {
+        return sb_ajax_object.site_url;
+    },
+
+    /**
+     * Get the URL to retrieve the environment configuration.
+     * @returns {Promise<string>}
+     */
+    getConfigUrl: async function () {
+        return await this.getSiteUrl() + this.workerSuffix;
+    },
+
+    /**
+     * Retrieve the environment configuration.
+     *
+     * @returns {Promise<object|boolean|any>}
+     */
+    retrieveConfig: async function () {
+        if (this.useDummyData) {
+            return await this.dummyData();
+        }
+        try {
+            const response = await fetch(await this.getConfigUrl());
+            const configObject = await response.json();
+            return configObject;
+        } catch (error) {
+            //console.error(error);
+            return false;
+        }
+    },
+
+    /**
+     * Dummy data.
+     *
+     * @returns {Promise<{sb_acd_worker_3pp_proxy: boolean, sb_acd_image_resize: boolean, sb_acd_worker_google_fonts: boolean}>}
+     */
+    dummyData: async function () {
+        return {
+            sb_acd_image_resize: true,
+            sb_acd_worker_google_fonts: true,
+            sb_acd_worker_3pp_proxy: true
+        };
+    }
+};

--- a/src/Servebolt/AcceleratedDomains/ImageResize/FeatureAccess.php
+++ b/src/Servebolt/AcceleratedDomains/ImageResize/FeatureAccess.php
@@ -14,7 +14,7 @@ class FeatureAccess
 {
 
     /**
-     * Check if current site has access to the Accelerated DOmains Image Resize feature.
+     * Check if current site has access to the Accelerated Domains Image Resize-feature.
      *
      * @param bool $purgeCache
      * @return bool

--- a/src/Servebolt/Admin/AcceleratedDomainsControl/AcceleratedDomainsControl.php
+++ b/src/Servebolt/Admin/AcceleratedDomainsControl/AcceleratedDomainsControl.php
@@ -47,7 +47,10 @@ class AcceleratedDomainsControl
 
     public function enqueueScripts(): void
     {
-        if (!isScreen('servebolt_page_servebolt-acd')) {
+        if (
+            !isScreen('servebolt_page_servebolt-acd')
+            && !isScreen('admin_page_servebolt-acd-image-resize')
+        ) {
             return;
         }
         wp_enqueue_script(

--- a/src/Servebolt/Admin/AcceleratedDomainsImageControl/AcceleratedDomainsImageResizeControl.php
+++ b/src/Servebolt/Admin/AcceleratedDomainsImageControl/AcceleratedDomainsImageResizeControl.php
@@ -5,6 +5,7 @@ namespace Servebolt\Optimizer\Admin\AcceleratedDomainsImageControl;
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use Servebolt\Optimizer\AcceleratedDomains\ImageResize\ImageSizeIndexModel;
+use Servebolt\Optimizer\Admin\AcceleratedDomainsImageControl\Ajax\DisableFeature;
 use Servebolt\Optimizer\Traits\Singleton;
 use function Servebolt\Optimizer\Helpers\getOption;
 use function Servebolt\Optimizer\Helpers\getOptionName;
@@ -31,8 +32,14 @@ class AcceleratedDomainsImageResizeControl
     public function __construct()
     {
         AcceleratedDomainsImageSizeIndexControl::getInstance();
+        $this->initAjax();
         $this->initSettings();
         $this->rewriteHighlightedMenuItem();
+    }
+
+    private function initAjax(): void
+    {
+        new DisableFeature;
     }
 
     /**

--- a/src/Servebolt/Admin/AcceleratedDomainsImageControl/Ajax/DisableFeature.php
+++ b/src/Servebolt/Admin/AcceleratedDomainsImageControl/Ajax/DisableFeature.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Servebolt\Optimizer\Admin\AcceleratedDomainsImageControl\Ajax;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+use Servebolt\Optimizer\AcceleratedDomains\ImageResize\AcceleratedDomainsImageResize;
+use Servebolt\Optimizer\Admin\SharedAjaxMethods;
+use function Servebolt\Optimizer\Helpers\ajaxUserAllowed;
+
+/**
+ * Class DisableFeature
+ * @package Servebolt\Optimizer\Admin\AcceleratedDomainsImageControl\Ajax
+ */
+class DisableFeature extends SharedAjaxMethods
+{
+    /**
+     * DisableFeature constructor.
+     */
+    public function __construct()
+    {
+        add_action('wp_ajax_servebolt_acd_image_resize_disable', [$this, 'disableAcceleratedDomainsImageResize']);
+    }
+
+    /**
+     * AJAX handling to disable the Accelerated Domains Image Resize-feature.
+     */
+    public function disableAcceleratedDomainsImageResize(): void
+    {
+        $this->checkAjaxReferer();
+        ajaxUserAllowed();
+        AcceleratedDomainsImageResize::toggleActive(false);
+        wp_send_json_success();
+    }
+}

--- a/src/Servebolt/Admin/Assets.php
+++ b/src/Servebolt/Admin/Assets.php
@@ -162,6 +162,13 @@ class Assets {
                 ['jquery'],
                 true
             );
+
+            $this->enqueueScript(
+                'servebolt-optimizer-env-config',
+                'assets/dist/js/env-config.js',
+                [],
+                true
+            );
             $this->enqueueScript(
                 'servebolt-optimizer-scripts-vanilla',
                 'assets/dist/js/general-vanilla.js',
@@ -176,6 +183,7 @@ class Assets {
             );
             wp_localize_script('servebolt-optimizer-cache-purge-trigger-scripts', 'sb_ajax_object', [
                 'ajax_nonce'                         => getAjaxNonce(),
+                'site_url'                           => get_site_url(),
                 'use_native_js_fallback'             => booleanToString($generalSettings->useNativeJsFallback()),
                 'ajaxurl'                            => admin_url('admin-ajax.php'),
                 'cron_purge_is_active'               => false, // TODO: Add real boolean value

--- a/src/Servebolt/Views/accelerated-domains/image-resize/settings-form.php
+++ b/src/Servebolt/Views/accelerated-domains/image-resize/settings-form.php
@@ -5,7 +5,7 @@
 
 <?php settings_errors(); ?>
 
-<form method="post" autocomplete="off" action="options.php">
+<form method="post" autocomplete="off" action="options.php" id="sb-accelerated-domains-image-resize-options-page-form">
     <?php settings_fields('sb-accelerated-domains-image-resize-options-page'); ?>
     <?php do_settings_sections('sb-accelerated-domains-image-resize-options-page'); ?>
 
@@ -16,13 +16,13 @@
                 <fieldset>
                     <legend class="screen-reader-text"><span><?php _e('Image resize-feature active?', 'servebolt-wp'); ?></span></legend>
                     <label for="acd_image_resize_switch">
-                        <input name="<?php echo getOptionName('acd_image_resize_switch'); ?>" type="checkbox" class="options-field-switch" id="acd_image_resize_switch" value="1" <?php checked($settings['acd_image_resize_switch']); ?>>
+                        <input name="<?php echo getOptionName('acd_image_resize_switch'); ?>" type="checkbox" disabled class="options-field-switch" id="acd_image_resize_switch" value="1" <?php checked($settings['acd_image_resize_switch']); ?>>
                         <?php _e('Enable', 'servebolt-wp'); ?>
                     </label><br>
                 </fieldset>
             </td>
         </tr>
-        <tbody id="options-fields"<?php if (!$settings['acd_image_resize_switch']) echo ' style="display: none;"'; ?>>
+        <tbody id="options-fields" style="display: none;">
             <tr>
                 <th scope="row"></th>
                 <td>


### PR DESCRIPTION
- WPSO-478 Add JavaScript-class to retrieve environment config
- Moved feature access check from PHP to JavaScript for the Accelerated Domains Image Resize-feature