### PR TITLE
WPSO-481 Convert cache header handling to handle plugin-agnostic ecommerce exceptions

### DIFF
--- a/src/Servebolt/Compatibility/WooCommerce/CacheExceptionRules.php
+++ b/src/Servebolt/Compatibility/WooCommerce/CacheExceptionRules.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Servebolt\Optimizer\Compatibility\WooCommerce;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+/**
+ * Class CacheExceptionRules
+ * @package Servebolt\Optimizer\Compatibility\WooCommerce
+ */
+class CacheExceptionRules
+{
+    /**
+     * CacheExceptionRules constructor.
+     */
+    public function __construct()
+    {
+        add_filter('sb_optimizer_fpc_ecommerce_pages_no_cache_bool', [$this, 'noCacheCheck'], 10, 1);
+        add_filter('sb_optimizer_fpc_ecommerce_pages_cache_bool', [$this, 'cacheCheck'], 10, 1);
+    }
+
+    /**
+     * Check if we are in a WooCommerce-context and check if we should not cache.
+     *
+     * @param null|boolean $shouldNotCache
+     * @return bool
+     */
+    public function noCacheCheck($shouldNotCache): bool
+    {
+        if (is_null($shouldNotCache)) {
+            return is_cart() || is_checkout() || is_account_page();
+        }
+        return $shouldNotCache;
+    }
+
+    /**
+     * Check if we are in a WooCommerce-context and check if we should cache.
+     *
+     * @param null|boolean $shouldCache
+     * @return bool
+     */
+    public function cacheCheck($shouldCache): bool
+    {
+        if (is_null($shouldCache)) {
+            return is_shop() || is_product_category() || is_product_tag() || is_product();
+        }
+        return $shouldCache;
+    }
+}

--- a/src/Servebolt/Compatibility/WooCommerce/WooCommerce.php
+++ b/src/Servebolt/Compatibility/WooCommerce/WooCommerce.php
@@ -25,5 +25,6 @@ class WooCommerce
         }
         new ProductVariationCachePurge;
         new ProductCachePurgeOnStockChange;
+        new CacheExceptionRules;
     }
 }

--- a/src/Servebolt/FullPageCache/FullPageCacheHeaders.php
+++ b/src/Servebolt/FullPageCache/FullPageCacheHeaders.php
@@ -162,12 +162,12 @@ class FullPageCacheHeaders
         // Only trigger this function once
         remove_filter('posts_results', [$this, 'setHeaders']);
 
-        if ($this->isWoocommerceNoCachePage()) {
+        if ($this->isEcommerceNoCachePage()) {
             $this->noCacheHeaders();
             if ($debug) {
                 $this->header('No-cache-trigger: 2');
             }
-        } elseif ($this->isWoocommerceCachePage()) {
+        } elseif ($this->isEcommerceCachePage()) {
             $this->cacheHeaders();
             if ($debug) {
                 $this->header('Cache-trigger: 11');
@@ -224,23 +224,23 @@ class FullPageCacheHeaders
     }
 
     /**
-     * Check if we are in a WooCommerce-context and check if we should not cache.
+     * Check if we are in an Ecommerce-context and check if we should not cache.
      *
      * @return bool
      */
-    private function isWoocommerceNoCachePage(): bool
+    private function isEcommerceNoCachePage(): bool
     {
-        return apply_filters('sb_optimizer_fpc_woocommerce_pages_no_cache_bool', (woocommerceIsActive() && (is_cart() || is_checkout() || is_account_page())));
+        return apply_filters('sb_optimizer_fpc_ecommerce_pages_no_cache_bool', null);
     }
 
     /**
-     * Check if we are in a WooCommerce-context and check if we should cache.
+     * Check if we are in an Ecommerce-context and check if we should cache.
      *
      * @return bool
      */
-    private function isWoocommerceCachePage(): bool
+    private function isEcommerceCachePage(): bool
     {
-        return apply_filters('sb_optimizer_fpc_woocommerce_pages_cache_bool', (woocommerceIsActive() && (is_shop() || is_product_category() || is_product_tag() || is_product())));
+        return apply_filters('sb_optimizer_fpc_ecommerce_pages_cache_bool', null);
     }
 
     /**


### PR DESCRIPTION
Added WooCommerce cache header exception through filters instead of direct implementation in FPC header-class