### PR TITLE
WPSO-485 Remove strict PHP typing from filter/action callbacks

### DIFF
--- a/src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php
+++ b/src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php
@@ -327,7 +327,7 @@ class PurgeActions extends SharedAjaxMethods
 
         try {
             setCachePurgeOriginEvent('manual_trigger');
-            WordPressCachePurge::purgeByTerm($termId, $term->taxonomy);
+            WordPressCachePurge::purgeByTerm((int) $termId, $term->taxonomy);
             if ($queueBasedCachePurgeIsActive) {
                 wp_send_json_success( [
                     'title'   => __('Just a moment', 'servebolt-wp'),

--- a/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/TermMethods.php
@@ -112,7 +112,11 @@ trait TermMethods
             }
             return isQueueItem($queueInstance->add($queueItemData));
         } else {
-            if (self::$preventDoublePurge && self::$preventTermDoublePurge && array_key_exists($termId . '-' . $taxonomySlug, self::$recentlyPurgedTerms)) {
+            if (
+                self::$preventDoublePurge
+                && self::$preventTermDoublePurge
+                && array_key_exists($termId . '-' . $taxonomySlug, self::$recentlyPurgedTerms)
+            ) {
                 return self::$recentlyPurgedTerms[$termId . '-' . $taxonomySlug];
             }
             $urlsToPurge = self::getUrlsToPurgeByTermId($termId, $taxonomySlug);

--- a/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
@@ -64,7 +64,7 @@ class WordPressCachePurge
             add_filter('sb_optimizer_purge_by_post_original_url', function() use ($url) {
                 return $url;
             });
-            return self::purgePostCache($postId);
+            return self::purgePostCache((int) $postId);
         } else {
             if ($shouldPurgeByQueue) {
                 $queueInstance = WpObjectQueue::getInstance();

--- a/src/Servebolt/CachePurge/WpObjectCachePurgeActions/AttachmentUpdateTrigger.php
+++ b/src/Servebolt/CachePurge/WpObjectCachePurgeActions/AttachmentUpdateTrigger.php
@@ -54,7 +54,7 @@ class AttachmentUpdateTrigger
      */
     public function wpImageEditorCallback(): void
     {
-        if ($this->shouldActOnThisAjaxAction() && $attachmentId = (int) $_POST['postid']) {
+        if ($this->shouldActOnThisAjaxAction() && $attachmentId = $_POST['postid']) {
             $this->purgeCacheForAttachment($attachmentId);
         }
     }
@@ -66,19 +66,19 @@ class AttachmentUpdateTrigger
      */
     private function shouldActOnThisAjaxAction(): bool
     {
-        return in_array(arrayGet('do', $_POST), ['restore', 'save', 'scale']);
+        return in_array(arrayGet('do', $_POST, []), ['restore', 'save', 'scale']);
     }
 
     /**
      * Purge cache for attachment on metadata generation.
      *
-     * @param int $attachmentId
+     * @param int|mixed $attachmentId The ID of the attachment that should be purged cache for.
      */
-    public function purgeCacheForAttachment(int $attachmentId): void
+    public function purgeCacheForAttachment($attachmentId): void
     {
         try {
             setCachePurgeOriginEvent('attachment_updated');
-            WordPressCachePurge::purgeByPostId($attachmentId);
+            WordPressCachePurge::purgeByPostId((int) $attachmentId);
         } catch (Exception $e) {}
     }
 }

--- a/src/Servebolt/CachePurge/WpObjectCachePurgeActions/ContentChangeTrigger.php
+++ b/src/Servebolt/CachePurge/WpObjectCachePurgeActions/ContentChangeTrigger.php
@@ -9,6 +9,7 @@ use Servebolt\Optimizer\CachePurge\CachePurge;
 use Exception;
 use Servebolt\Optimizer\Traits\EventToggler;
 use Servebolt\Optimizer\Traits\Singleton;
+use function Servebolt\Optimizer\Helpers\arrayGet;
 use function Servebolt\Optimizer\Helpers\setCachePurgeOriginEvent;
 
 /**
@@ -23,7 +24,7 @@ class ContentChangeTrigger
     public function deregisterEvents(): void
     {
         remove_action('edit_term', [$this, 'purgeTermOnSave'], 99, 3);
-        remove_action('save_post', [$this, 'purgePostOnSave'], 99, 3);
+        remove_action('save_post', [$this, 'purgePostOnSave'], 99, 1);
         remove_action('comment_post', [$this, 'purgePostOnCommentPost'], 99, 3);
         remove_action('transition_comment_status', [$this, 'purgePostOnCommentApproval'], 99, 3);
     }
@@ -51,7 +52,7 @@ class ContentChangeTrigger
 
         // Purge post on post update
         if (apply_filters('sb_optimizer_automatic_purge_on_post_save', true)) {
-            add_action('save_post', [$this, 'purgePostOnSave'], 99, 3);
+            add_action('save_post', [$this, 'purgePostOnSave'], 99, 1);
         }
 
         // Purge post on comment post
@@ -66,22 +67,24 @@ class ContentChangeTrigger
     }
 
     /**
-     * @param $termId
-     * @param $termTaxonomyId
-     * @param $taxonomy
+     * Purge cache for term on save.
+     *
+     * @param int $termId The term ID.
+     * @param int $termTaxonomyId The term taxonomy ID.
+     * @param string $taxonomy The taxonomy slug.
      */
     public function purgeTermOnSave($termId, $termTaxonomyId, $taxonomy): void
     {
-        $this->maybePurgeTerm($termId, $taxonomy);
+        $this->maybePurgeTerm((int) $termId, (string) $taxonomy);
     }
 
     /**
      * Check whether we should purge cache for given term.
      *
-     * @param $termId
-     * @param $taxonomy
+     * @param int $termId
+     * @param string|mixed $taxonomy
      */
-    private function maybePurgeTerm($termId, $taxonomy): void
+    private function maybePurgeTerm(int $termId, string $taxonomy): void
     {
         if (!$this->shouldPurgeTermCache($termId, $taxonomy)) {
             return;
@@ -95,16 +98,27 @@ class ContentChangeTrigger
     /**
      * Check if we should clear cache for post that is being updated.
      *
-     * @param $termId
-     * @param $taxonomy
+     * @param int $termId
+     * @param string $taxonomy
      *
      * @return bool|void
      */
-    private function shouldPurgeTermCache($termId, $taxonomy): bool
+    private function shouldPurgeTermCache(int $termId, string $taxonomy): bool
     {
 
-        // Let users override the outcome
-        $overrideByTermId = apply_filters('sb_optimizer_should_purge_term_cache', null, $termId, $taxonomy);
+        /**
+         * Let 3rd party devs decide whether we should purge term cache or not.
+         *
+         * @param null|boolean $shouldPurge Whether to purge the cache or not.
+         * @param int $termId The ID of the term.
+         * @param string $taxonomy The taxonomy slug.
+         */
+        $overrideByTermId = apply_filters(
+            'sb_optimizer_should_purge_term_cache',
+            null,
+            $termId,
+            $taxonomy
+        );
         if (is_bool($overrideByTermId)) {
             return $overrideByTermId;
         }
@@ -188,49 +202,60 @@ class ContentChangeTrigger
     /**
      * Purge post on post save.
      *
-     * @param int $postId
-     * @param WP_Post|object $post
-     * @param bool $update
+     * @param int|mixed $postId
      */
-    public function purgePostOnSave(int $postId, object $post, bool $update): void
+    public function purgePostOnSave($postId): void
     {
-        $this->maybePurgePost($postId);
+        $this->maybePurgePost((int) $postId);
     }
 
     /**
      * Maybe purge post by post ID.
      *
-     * @param $postId
+     * @param int $postId
      */
-    private function maybePurgePost($postId): void
+    private function maybePurgePost(int $postId): void
     {
         if (!self::shouldPurgePostCache($postId)) {
             return;
         }
         try {
             setCachePurgeOriginEvent('post_change');
-            WordPressCachePurge::purgeByPostId($postId);
+            WordPressCachePurge::purgeByPostId((int) $postId);
         } catch (Exception $e) {}
     }
 
     /**
      * Purge post cache on comment post.
      *
-     * @param $commentId
-     * @param $commentApproved
-     * @param $commentData
+     * @param int $commentId
+     * @param int|string $commentApproved
+     * @param array $commentData
      */
     public function purgePostOnCommentPost($commentId, $commentApproved, $commentData): void
     {
-        $postId = $this->getPostIdFromComment($commentData);
+        $postId = $this->getPostIdFromComment((array) $commentData);
 
         // Bail on the cache purge if we could not figure out which post was commented on
         if (!$postId) {
             return;
         }
 
-        // Bail on the cache purge if the comment needs to be approved first
-        $commentIsApproved = apply_filters('sb_optimizer_comment_approved_cache_purge', $commentApproved, $commentData, $commentId);
+        /**
+         * Bail on the cache purge if the comment needs to be approved first.
+         *
+         * @param int|string $commentApproved Whether the comment is approved, or whether it's spam.
+         * @param array $commentData An array containing the comment data.
+         * @param int $commentId The ID of the comment.
+         * @param int $post The ID of the post where the comment was posted.
+         */
+        $commentIsApproved = apply_filters(
+            'sb_optimizer_comment_approved_cache_purge',
+            $commentApproved,
+            $commentData,
+            $commentId,
+            $postId
+        );
         if (
             apply_filters('sb_optimizer_prevent_cache_purge_on_unapproved_comments', true)
             && !$commentIsApproved
@@ -252,7 +277,7 @@ class ContentChangeTrigger
     {
         $statusDidChange = $oldStatus != $newStatus;
         if ($statusDidChange && $newStatus == 'approved') {
-            $postId = $this->getPostIdFromComment($commentData);
+            $postId = $this->getPostIdFromComment((array) $commentData);
             if (!$postId) {
                 return;
             }
@@ -263,16 +288,16 @@ class ContentChangeTrigger
     /**
      * Get post ID from comment data.
      *
-     * @param $commentData
+     * @param array $commentData
      *
-     * @return bool|int
+     * @return null|int
      */
-    private function getPostIdFromComment($commentData)
+    private function getPostIdFromComment(array $commentData): ?int
     {
-        $commentData = (array) $commentData;
-        if (!array_key_exists('comment_post_ID', $commentData)) {
-            return false;
+        $commentPostId = arrayGet('comment_post_ID', $commentData);
+        if (!$commentPostId) {
+            return null;
         }
-        return $commentData['comment_post_ID'];
+        return (int) $commentPostId;
     }
 }

--- a/src/Servebolt/CachePurge/WpObjectCachePurgeActions/DeletionCacheTrigger.php
+++ b/src/Servebolt/CachePurge/WpObjectCachePurgeActions/DeletionCacheTrigger.php
@@ -73,7 +73,12 @@ class DeletionCacheTrigger
         if (!$termId) {
             return;
         }
-        $taxonomySlug = (getTaxonomyFromTermId($termId))->name;
+        $termId = (int) $termId;
+        $taxonomyObject = getTaxonomyFromTermId($termId);
+        if (!$taxonomyObject) {
+            return;
+        }
+        $taxonomySlug = $taxonomyObject->name;
         try {
             setCachePurgeOriginEvent('term_deleted');
             WordPressCachePurge::skipQueueOnce();
@@ -86,12 +91,12 @@ class DeletionCacheTrigger
      *
      * @param int $postId
      */
-    public function deletePost(int $postId): void
+    public function deletePost($postId): void
     {
         try {
             setCachePurgeOriginEvent('post_deleted');
             WordPressCachePurge::skipQueueOnce();
-            WordPressCachePurge::purgeByPostId($postId);
+            WordPressCachePurge::purgeByPostId((int) $postId);
         } catch (Exception $e) {}
     }
 }

--- a/src/Servebolt/CloudflareImageResize/CloudflareImageResize.php
+++ b/src/Servebolt/CloudflareImageResize/CloudflareImageResize.php
@@ -74,17 +74,17 @@ class CloudflareImageResize
     {
 
         // Alter srcset-attribute URLs
-        if ( apply_filters('sb_optimizer_cf_image_resize_alter_srcset', true ) ) {
+        if (apply_filters('sb_optimizer_cf_image_resize_alter_srcset', true)) {
             add_filter('wp_calculate_image_srcset', [$this, 'alterSrcsetImageUrls']);
         }
 
         // Alter image src-attribute URL
-        if ( apply_filters('sb_optimizer_cf_image_resize_alter_src', true ) ) {
+        if (apply_filters('sb_optimizer_cf_image_resize_alter_src', true)) {
             add_filter('wp_get_attachment_image_src', [$this, 'alterSingleImageUrl']);
         }
 
         // Prevent certain image sizes to be created since we are using Cloudflare for resizing
-        if ( apply_filters('sb_optimizer_cf_image_resize_alter_intermediate_sizes', true ) ) {
+        if (apply_filters('sb_optimizer_cf_image_resize_alter_intermediate_sizes',true)) {
             ImageSizeCreationOverride::getInstance();
         }
     }

--- a/src/Servebolt/Compatibility/WooCommerce/ProductCachePurgeOnStockChange.php
+++ b/src/Servebolt/Compatibility/WooCommerce/ProductCachePurgeOnStockChange.php
@@ -49,11 +49,13 @@ class ProductCachePurgeOnStockChange
                      * Determine whether we should do an immediate purge whenever the product stock changes.
                      *
                      * @param bool $forceImmediatePurge Whether we should force an immediate purge or not.
+                     * @param int $productId The product to be purged cache for.
                      * @param string $context The context of the purge.
                      */
                     if (apply_filters(
                         'sb_optimizer_woocommerce_force_immediate_purge',
                         true,
+                        $productId,
                         'woocommerce_product_stock_change'
                     )) {
                         WordPressCachePurge::purgeImmediately();
@@ -63,11 +65,13 @@ class ProductCachePurgeOnStockChange
                      * Determine whether we should do a simple purge whenever the product stock changes.
                      *
                      * @param bool $doSimplePurge Whether we should do a simple purge or not.
+                     * @param int $productId The product to be purged cache for.
                      * @param string $context The context of the purge.
                      */
                     if (apply_filters(
                         'sb_optimizer_woocommerce_do_simple_purge',
                         true,
+                        $productId,
                         'woocommerce_product_stock_change'
                     )) {
                         WordPressCachePurge::purgePostCacheSimple($productId);
@@ -134,7 +138,7 @@ class ProductCachePurgeOnStockChange
     private function shouldPurgeCacheOnStockStatusChange(): bool
     {
         if (apply_filters('sb_optimizer_woocommerce_product_cache_purge_on_stock_status_change', true) === false) {
-            return false; // We're not suppose to purge cache on WooCommerce stock status change
+            return false; // We're not supposed to purge cache on WooCommerce stock status change
         }
 
         return $this->shouldPurgeCacheOnStockCommonCondition();
@@ -196,7 +200,7 @@ class ProductCachePurgeOnStockChange
             && method_exists($product, 'get_id')
         ) {
             if ($productId = $product->get_id()) {
-                return $productId;
+                return (int) $productId;
             }
         }
         return null;

--- a/src/Servebolt/FullPageCache/FullPageCache.php
+++ b/src/Servebolt/FullPageCache/FullPageCache.php
@@ -64,7 +64,7 @@ class FullPageCache
 
         add_action('sb_optimizer_post_added_to_html_cache_exclusion', function($postId) {
             try {
-                WordPressCachePurge::purgeByPostId($postId);
+                WordPressCachePurge::purgeByPostId((int) $postId);
             } catch (Exception $e) {}
         }, 10, 1);
     }


### PR DESCRIPTION
Fixed cache purge WP action/filter interaction in regards to argument types