### PR TITLE
WPSO-499 Clear cache purge table when driver is changed

### DIFF
--- a/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
+++ b/src/Servebolt/CachePurge/WordPressCachePurge/WordPressCachePurge.php
@@ -175,30 +175,6 @@ class WordPressCachePurge
     }
 
     /**
-     * Purge CDN cache on the site.
-     *
-     * @param bool $returnWpError
-     * @return bool
-     */
-    public static function purgeCdn(bool $returnWpError = false)
-    {
-        $driver = ServeboltCdnDriver::getInstance();
-        return $driver->purgeCdn();
-    }
-
-    /**
-     * Purge CDN cache in network (only for multisites).
-     *
-     * @param bool $returnWpError
-     * @return bool
-     */
-    public static function purgeCdnNetwork(bool $returnWpError = false)
-    {
-        $driver = ServeboltCdnDriver::getInstance();
-        return $driver->purgeCdnNetwork();
-    }
-
-    /**
      * Purge all cache for given site (only for multisites).
      *
      * @param int $blogId

--- a/src/Servebolt/Queue/Queues/UrlQueue.php
+++ b/src/Servebolt/Queue/Queues/UrlQueue.php
@@ -159,10 +159,12 @@ class UrlQueue
 
     /**
      * Clear queue.
+     *
+     * @param bool $skipConstraintBoolean
      */
-    public function clearQueue(): void
+    public function clearQueue(bool $skipConstraintBoolean = false): void
     {
-        $this->queue->clearQueue();
+        $this->queue->clearQueue($skipConstraintBoolean);
     }
 
     /**

--- a/src/Servebolt/Queue/Queues/WpObjectQueue.php
+++ b/src/Servebolt/Queue/Queues/WpObjectQueue.php
@@ -134,10 +134,12 @@ class WpObjectQueue
 
     /**
      * Clear queue.
+     *
+     * @param bool $skipConstraintBoolean
      */
-    public function clearQueue(): void
+    public function clearQueue(bool $skipConstraintBoolean = false): void
     {
-        $this->queue->clearQueue();
+        $this->queue->clearQueue($skipConstraintBoolean);
     }
 
     /**


### PR DESCRIPTION
- Minor cleanup
- Added so that the cache purge queue gets cleared every time we switch the cache purge driver (because we could end up with items in the queue that originates from a different drivers with different cache purge methods available)