### PR TITLE
WPSO-502 Prefetching not working

### DIFF
--- a/src/Servebolt/AcceleratedDomains/Prefetching/ManifestFileWriter.php
+++ b/src/Servebolt/AcceleratedDomains/Prefetching/ManifestFileWriter.php
@@ -44,7 +44,8 @@ class ManifestFileWriter
      *
      * @var string
      */
-    private static $fileNameMask = 'manifest-%s-%s.txt';
+    //private static $fileNameMask = 'manifest-%s-%s.txt';
+    private static $fileNameMask = 'manifest-%s.txt';
 
     /**
      * WP Filesystem instance.
@@ -145,7 +146,8 @@ class ManifestFileWriter
      */
     public static function generateFileName(string $fileType): string
     {
-        return sprintf(self::$fileNameMask, $fileType, time());
+        //return sprintf(self::$fileNameMask, $fileType, time());
+        return sprintf(self::$fileNameMask, $fileType);
     }
 
     /**

--- a/src/Servebolt/AcceleratedDomains/Prefetching/Prefetching.php
+++ b/src/Servebolt/AcceleratedDomains/Prefetching/Prefetching.php
@@ -257,7 +257,7 @@ class Prefetching
     {
         return (bool) apply_filters(
             'sb_optimizer_prefetching_expose_manifest_files_after_prefetch_items_record',
-            true
+            false
         );
     }
 


### PR DESCRIPTION
Removed timestamp from manifest filename (due to issues with cached headers that specify the manifest file URLs resulting in 404's for the Cloudflare Prefetch-agent)