### PR TITLE
Cache tags - Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ If you want to build a local production-ready version of the plugin you can run 
 
 ## Changelog
 
+#### 3.5.57
+* Bugfix: fixed slow cache clear on chrome browsers, and enabled cache clear on firefox correctly
+* New Feature: Option for cloudflare direct communicaitons to work with Cache-Tags for purging.  This enhances perfomance of those that have a cloudflare plan on Servebolt.
+
 #### 3.5.56
 * Bugfix: fixed malformed http response headers when selecting 0 seconds for specific post type cache TTL for Accelerated Domains. 
 #### 3.5.55

--- a/Readme.txt
+++ b/Readme.txt
@@ -3,9 +3,9 @@ Contributors: audunhus, erlendeide, servebolt, andrewkillen
 Tags: performance, optimization, html cache, cloudflare , multisite
 Donate link: https://servebolt.com
 Requires at least: 4.9.2
-Tested up to: 6.7.2
+Tested up to: 6.8.1
 Requires PHP: 7.4
-Stable tag: 3.5.56
+Stable tag: 3.5.57
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -97,6 +97,11 @@ Yes, you can. The database optimizations are beneficial for everyone as well as 
 If you're a Servebolt client, please reach out to our Support Team and we'll be happy to help you out there. Alternatively, you can create a support forum request [here](https://wordpress.org/support/plugin/servebolt-optimizer/).
 
 == Changelog ==
+
+= 3.5.57 =
+* Bugfix: fixed slow cache clear on chrome browsers, and enabled cache clear on firefox correctly
+* New Feature: Option for cloudflare direct communicaitons to work with Cache-Tags for purging.  This enhances perfomance of those that have a cloudflare plan on Servebolt.
+
 
 = 3.5.56 =
 * Bugfix: fixed malformed http response headers when selecting 0 seconds for specific post type cache TTL for Accelerated Domains. 
@@ -232,45 +237,3 @@ If you're a Servebolt client, please reach out to our Support Team and we'll be 
 * Tested upto 6.4.1
 * Fixed bug in cache by term id, now uses CacheTags whenever possible.
 * Added check for Image sizes on Accellerated Domains image resizer so that it can never have a zero value.
-
-= 3.5.24 =
-* fixed small bug of missing save button on advanced tab of new installs
-* proven support for 6.3.1
-
-= 3.5.23 =
-* Small text changes in WP Cron configuration area.
-* Adapted links to include a link to the advanced tab for enabling or disabling cron.
-* Cron enabled checkbox also takes account of the DISABLE_WP_CRON constant, not just the option.
-* proven support for WP 6.3
-
-= 3.5.22 =
-* bump release
-
-= 3.5.21 =
-* added cache-tag headers to search pages, so that they can optionally be cached. Acellerated Domains feature only.
-
-= 3.5.20 =
-* fixed "PHP Deprecated" error when using PHP8.0+ and WP_DEBUG is set to TRUE.
-
-= 3.5.19 =
-* updated supported WordPress version.
-
-= 3.5.18 =
-* hid the 'purge by taxonomy term' menu and quick menu buttons for Servebolt CDN customers. This feature is not possible for them and should not have been showing.
-
-= 3.5.17 =
-bump release. no changes.
-
-= 3.5.16 =
-* Added CacheTags to Servebolt CDN
-* Added HTML cache purging to Servebolt CDN
-
-= 3.5.15 =
-* Bugfix for purge queue on large sites. It was giving CRON errors.
-* Added filter to allow for adaption of headers on Full Page Caching.
-
-= 3.5.14 =
-* version bump to force release 
-
-= 3.5.13 =
-* Bugfix for Cloudflare direct purging via purge queue. it was not created purge records correctly.

--- a/languages/servebolt-optimizer.pot
+++ b/languages/servebolt-optimizer.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-06-12T13:06:06+00:00\n"
+"POT-Creation-Date: 2025-06-18T20:07:53+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: servebolt-wp\n"
@@ -1250,21 +1250,21 @@ msgstr ""
 msgid "%sGet in touch with our support via chat%s if you need assistance with resolving this issue."
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1257
-#: src/Servebolt/Helpers/Helpers.php:1269
+#: src/Servebolt/Helpers/Helpers.php:1258
+#: src/Servebolt/Helpers/Helpers.php:1270
 #: src/Servebolt/Views/accelerated-domains/image-resize/image-size-index-list.php:12
 msgid "Delete"
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1258
+#: src/Servebolt/Helpers/Helpers.php:1259
 msgid "View"
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1260
+#: src/Servebolt/Helpers/Helpers.php:1261
 msgid "Edit"
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1267
+#: src/Servebolt/Helpers/Helpers.php:1268
 msgid "Post does not exist."
 msgstr ""
 
@@ -1395,6 +1395,7 @@ msgstr ""
 #: src/Servebolt/Views/accelerated-domains/image-resize/settings-form.php:82
 #: src/Servebolt/Views/accelerated-domains/prefetching/settings-form.php:20
 #: src/Servebolt/Views/accelerated-domains/prefetching/settings-form.php:65
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:22
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/configuration.php:45
 #: src/Servebolt/Views/cache-settings/cache-settings/settings-form.php:22
 #: src/Servebolt/Views/cache-settings/cache-settings/settings-form.php:102
@@ -1725,8 +1726,8 @@ msgid "Environment API key"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/acd-configuration.php:24
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:34
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:55
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:49
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:70
 msgid "Show password"
 msgstr ""
 
@@ -1743,59 +1744,67 @@ msgstr ""
 msgid "Purge All Caches"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:8
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:11
 msgid "Cloudflare API"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:9
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:12
 msgid "Servebolt Optimizer connects to the Cloudflare cache through the Cloudflare API. Best practice is to use API token for authentication."
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:13
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:16
-msgid "Authentication type"
-msgstr ""
-
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:18
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:29
-msgid "API token"
+msgid "Cache-Tags"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:19
+msgid "Use Cache Tags"
+msgstr ""
+
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:28
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:31
+msgid "Authentication type"
+msgstr ""
+
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:33
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:44
+msgid "API token"
+msgstr ""
+
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:34
 msgid "How to make an API token"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:22
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:51
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:37
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:66
 msgid "API key"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:23
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:38
 msgid "How to get your API key"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:40
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:55
 #, php-format
 msgid "Make sure to add permissions for %s when creating a token."
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:44
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:59
 msgid "Cloudflare e-mail"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:63
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:78
 msgid "Cloudflare Zone ID"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:68
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:83
 msgid "You can find the Zone ID in the Cloudflare Overview tab of the zone you'd like to connect, in the right sidebar under the API section."
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:72
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:87
 msgid "Selected zone:"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:75
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:90
 msgid "Available zones:"
 msgstr ""
 

--- a/languages/servebolt-optimizer.pot
+++ b/languages/servebolt-optimizer.pot
@@ -1,46 +1,53 @@
-# Copyright (C) 2024 Servebolt
+# Copyright (C) 2025 Servebolt
 # This file is distributed under the GPLv3 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Servebolt Optimizer 3.5.46\n"
+"Project-Id-Version: Servebolt Optimizer 3.5.56\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/servebolt-optimizer\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-12-12T16:43:22+01:00\n"
+"POT-Creation-Date: 2025-06-12T13:06:06+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.7.1\n"
+"X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: servebolt-wp\n"
 
 #. Plugin Name of the plugin
+#: servebolt-optimizer.php
 #: src/Servebolt/Admin/AdminBarGui/AdminBarGui.php:103
 msgid "Servebolt Optimizer"
 msgstr ""
 
 #. Description of the plugin
+#: servebolt-optimizer.php
 msgid "A plugin that implements Servebolt Security & Performance best practises for WordPress."
 msgstr ""
 
 #. Author of the plugin
+#: servebolt-optimizer.php
 #: src/Servebolt/Admin/AdminController.php:180
 msgid "Servebolt"
 msgstr ""
 
 #. Author URI of the plugin
+#: servebolt-optimizer.php
 msgid "https://servebolt.com"
 msgstr ""
 
 #: php-outdated.php:16
+#, php-format
 msgid "This site is running on a lower PHP version than required by the Servebolt Optimizer plugin. Please upgrade your site to run PHP %s or higher. We highly recommend upgrading to the highest available PHP version."
 msgstr ""
 
 #: php-outdated.php:17
+#, php-format
 msgid "%sGet in touch with our support%s if you need assistance upgrading your site to a newer PHP version."
 msgstr ""
 
 #: php-outdated.php:24
+#, php-format
 msgid "Servebolt Optimizer cannot run on PHP-versions older than PHP %s. You currently run PHP version %s. Please upgrade your PHP version to be able to run Servebolt Optimizer."
 msgstr ""
 
@@ -50,7 +57,7 @@ msgstr ""
 
 #: src/Servebolt/Admin/AcceleratedDomainsControl/Ajax/PurgeActions.php:37
 #: src/Servebolt/Admin/AcceleratedDomainsControl/Ajax/PurgeActions.php:62
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:54
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:55
 msgid "The cache purge feature is not active or is not configured correctly, so we could not purge cache."
 msgstr ""
 
@@ -83,20 +90,29 @@ msgid "Size does not exist."
 msgstr ""
 
 #: src/Servebolt/Admin/AdminBarGui/Nodes/1_ServeboltControlPanelNode.php:41
-msgid "Servebolt Control Panel"
+#: src/Servebolt/Views/cache-settings/cache-settings/promo.php:4
+#: src/Servebolt/Views/cache-settings/cache-settings/promo.php:20
+#: src/Servebolt/Views/performance-optimizer/menu-optimizer/promo.php:4
+msgid "Servebolt Admin Panel"
 msgstr ""
 
-#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:71
+#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:72
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cache-purge-triggers.php:6
 msgid "Purge CDN Cache"
 msgstr ""
 
-#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:92
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cache-purge-triggers.php:8
+#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:94
+msgid "Purge Server Cache"
+msgstr ""
+
+#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:114
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cache-purge-triggers.php:9
 msgid "Purge a URL"
 msgstr ""
 
-#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:115
-#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:141
+#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:137
+#: src/Servebolt/Admin/AdminBarGui/Nodes/2_CachePurgeNodes.php:163
+#, php-format
 msgid "Purge %s cache"
 msgstr ""
 
@@ -138,7 +154,7 @@ msgstr ""
 
 #: src/Servebolt/Admin/AdminController.php:237
 #: src/Servebolt/Views/accelerated-domains/control/accelerated-domains.php:5
-#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:12
+#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:15
 #: src/Servebolt/Views/accelerated-domains/image-resize/image-resize.php:7
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/configuration.php:63
 #: src/Servebolt/Views/cache-settings/cache-settings/promo.php:30
@@ -211,141 +227,163 @@ msgstr ""
 msgid "Validation errors:"
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:146
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:164
 msgid "Please specify the URL you would like to purge cache for."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:154
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:246
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:393
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:172
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:264
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:411
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:447
 msgid "All good!"
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:165
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:257
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:359
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:404
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:183
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:275
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:377
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:422
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:458
 msgid "Just a moment"
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:166
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:184
+#, php-format
 msgid "A cache purge request for the URL \"%s\" was added to the queue and will be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:169
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:187
+#, php-format
 msgid "Cache was purged for URL \"%s\"."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:233
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:251
 msgid "Please specify the post you would like to purge cache for."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:236
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:254
 msgid "The specified post does not exist."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:239
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:257
 msgid "You are not allowed to purge cache for this post."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:247
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:265
+#, php-format
 msgid "A cache purge request for the %s \"%s\" is already added to the queue and should be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:258
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:276
+#, php-format
 msgid "A cache purge request for the %s \"%s\" was added to the queue and will be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:261
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:279
+#, php-format
 msgid "Cache was purged for the %s \"%s\"."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:334
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:352
 msgid "Please specify the term you would like to purge cache for."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:337
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:355
 msgid "The specified term does not exist."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:340
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:358
 msgid "You are not allowed to purge cache for this taxonomy."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:349
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:367
+#, php-format
 msgid "A cache purge request for the term \"%s\" is already added to the queue and should be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:360
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:378
+#, php-format
 msgid "A cache purge request for the term \"%s\" was added to the queue and will be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:363
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:381
+#, php-format
 msgid "Cache was purged for the term \"%s\"."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:394
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:412
 msgid "A purge all-request is already queued and should be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:405
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:423
 msgid "A purge all-request was added to the queue and will be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:408
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:426
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:462
 msgid "All cache was purged."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:496
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:448
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:459
+msgid "A Purge Server Cache -request is already queued and should be executed shortly."
+msgstr ""
+
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:550
 msgid "See result below:"
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:499
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:553
 msgid "We we're not successful..."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:500
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:554
 msgid "We got some errors, please see below:"
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:503
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:557
 msgid "We we're not quite successful..."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:504
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:558
 msgid "We got a partial success due to some errors, please see the messages below:"
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:507
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:561
 msgid "We we're almost successful..."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:508
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:562
 msgid "Some actions could not be completed, please see below:"
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:525
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:579
+#, php-format
 msgid "Could not purge all cache since cache purge feature is not active on site %s."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:531
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:585
+#, php-format
 msgid "Could not purge all cache since cache purge feature is not configured on site %s."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:542
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:596
+#, php-format
 msgid "A purge all-request is already queued on site %s and will be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:553
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:607
+#, php-format
 msgid "A purge all-request was added to the queue on site %s and will be executed shortly."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:558
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:612
+#, php-format
 msgid "All cache was purged on site %s."
 msgstr ""
 
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:564
-#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:569
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:618
+#: src/Servebolt/Admin/CachePurgeControl/Ajax/PurgeActions.php:623
+#, php-format
 msgid "Could not purge cache on site %s."
 msgstr ""
 
@@ -357,7 +395,7 @@ msgid "Cache Purging"
 msgstr ""
 
 #: src/Servebolt/Admin/CachePurgeControl/CachePurgeRowActions.php:115
-#: src/Servebolt/Admin/CachePurgeControl/CachePurgeRowActions.php:141
+#: src/Servebolt/Admin/CachePurgeControl/CachePurgeRowActions.php:145
 msgid "Purge cache"
 msgstr ""
 
@@ -375,6 +413,7 @@ msgid "We made progress, but..."
 msgstr ""
 
 #: src/Servebolt/Admin/FullPageCacheControl/Ajax/HtmlCachePostExclusion.php:168
+#, php-format
 msgid "The following %s were invalid:"
 msgstr ""
 
@@ -419,15 +458,18 @@ msgid "Cache TTL"
 msgstr ""
 
 #: src/Servebolt/Admin/PerformanceOptimizer/Ajax/DatabaseOptimizationActions.php:65
+#, php-format
 msgid "Table \"%s\" already has index."
 msgstr ""
 
 #: src/Servebolt/Admin/PerformanceOptimizer/Ajax/DatabaseOptimizationActions.php:69
 #: src/Servebolt/Admin/PerformanceOptimizer/Ajax/DatabaseOptimizationActions.php:73
+#, php-format
 msgid "Added index to table \"%s\"."
 msgstr ""
 
 #: src/Servebolt/Admin/PerformanceOptimizer/Ajax/DatabaseOptimizationActions.php:77
+#, php-format
 msgid "Could not add index to table \"%s\"."
 msgstr ""
 
@@ -479,14 +521,17 @@ msgid "Prefetching"
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomains.php:94
+#, php-format
 msgid "Accelerated Domains is %s."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomains.php:141
+#, php-format
 msgid "Accelerated Domains already active on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomains.php:144
+#, php-format
 msgid "Accelerated Domains activated on site %s."
 msgstr ""
 
@@ -499,10 +544,12 @@ msgid "Accelerated Domains activated."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomains.php:218
+#, php-format
 msgid "Accelerated Domains already inactive on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomains.php:221
+#, php-format
 msgid "Accelerated Domains deactivated on site %s."
 msgstr ""
 
@@ -515,18 +562,22 @@ msgid "Accelerated Domains deactivated."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageResize.php:80
+#, php-format
 msgid "Note: %s"
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageResize.php:115
+#, php-format
 msgid "Accelerated Domains Image Resize feature is %s."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageResize.php:186
+#, php-format
 msgid "Accelerated Domains Image Resize feature already active on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageResize.php:189
+#, php-format
 msgid "Accelerated Domains Image Resize feature activated on site %s."
 msgstr ""
 
@@ -539,10 +590,12 @@ msgid "Accelerated Domains Image Resize feature activated."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageResize.php:263
+#, php-format
 msgid "Accelerated Domains Image Resize feature already inactive on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageResize.php:266
+#, php-format
 msgid "Accelerated Domains Image Resize feature deactivated on site %s."
 msgstr ""
 
@@ -555,7 +608,7 @@ msgid "Accelerated Domains Image Resize feature deactivated."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageResize.php:310
-msgid "Your bolt-subscription does not seem have access to the Accelerated Domains Image Resize-feature and the feature will therefore not operate. The feature can be enabled in the control panel."
+msgid "Your bolt-subscription does not seem have access to the Accelerated Domains Image Resize-feature and the feature will therefore not operate. The feature can be enabled in the admin panel."
 msgstr ""
 
 #: src/Servebolt/Cli/AcceleratedDomains/AcceleratedDomainsImageSizeIndex.php:61
@@ -728,26 +781,32 @@ msgid "Current cache purge driver does not support purging of URLs."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:79
+#, php-format
 msgid "Cache purged for URL \"%s\"."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:89
+#, php-format
 msgid "Could not purge cache for URL \"%s\". Make sure the cache purge feature is configured properly."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:101
+#, php-format
 msgid "Could not purge cache for URL \"%s\"."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:153
+#, php-format
 msgid "Cache purged for %s URLs."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:163
+#, php-format
 msgid "Could not purge cache for %s URLs. Make sure the cache purge feature is configured properly."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:175
+#, php-format
 msgid "Could not purge cache for %s URLs."
 msgstr ""
 
@@ -756,14 +815,17 @@ msgid "Current cache purge driver does not support purging of URLs/posts."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:221
+#, php-format
 msgid "Cache purged for post \"%s\" (ID %s)."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:231
+#, php-format
 msgid "Could not purge cache for post \"%s\" (ID %s). Make sure the cache purge feature is configured properly."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:243
+#, php-format
 msgid "Could not purge cache for post \"%s\" (ID %s)."
 msgstr ""
 
@@ -772,14 +834,17 @@ msgid "Current cache purge driver does not support purging of URLs/terms."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:294
+#, php-format
 msgid "Cache purged for term \"%s\" (ID %s)."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:304
+#, php-format
 msgid "Could not purge cache for term \"%s\" (ID %s). Make sure the cache purge feature is configured properly."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/PurgeActions.php:316
+#, php-format
 msgid "Could not purge cache for term \"%s\" (ID %s)."
 msgstr ""
 
@@ -808,6 +873,7 @@ msgid "Could not purge cache."
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/Queue.php:63
+#, php-format
 msgid "Cache purge queue cleared on site %s."
 msgstr ""
 
@@ -816,6 +882,7 @@ msgid "Cache purge queue cleared!"
 msgstr ""
 
 #: src/Servebolt/Cli/Cache/Queue.php:131
+#, php-format
 msgid "Cache purge queue trash cleared on site %s."
 msgstr ""
 
@@ -842,58 +909,72 @@ msgid "wp servebolt "
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:183
+#, php-format
 msgid "Value set to \"%s\"."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:322
+#, php-format
 msgid "Setting \"%s\" was cleared on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:324
+#, php-format
 msgid "Setting \"%s\" was cleared."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:350
+#, php-format
 msgid "Could not set setting \"%s\" to value \"%s\" on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:352
+#, php-format
 msgid "Could not set setting \"%s\" to value \"%s\"."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:365
+#, php-format
 msgid "Setting \"%s\" set to value \"%s\" on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:367
+#, php-format
 msgid "Setting \"%s\" set to value \"%s\"."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:410
+#, php-format
 msgid "Setting \"%s\" not found. Please run \"wp servebolt "
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:433
+#, php-format
 msgid "Available values are: %s"
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:436
+#, php-format
 msgid "Value need to be either %s."
 msgstr ""
 
 #: src/Servebolt/Cli/CliKeyValueStorage/CliKeyValueStorage.php:438
+#, php-format
 msgid "Value need to be \"%s\"."
 msgstr ""
 
 #: src/Servebolt/Cli/CloudflareImageResize/CloudflareImageResize.php:79
+#, php-format
 msgid "Cloudflare Image Resize feature is %s"
 msgstr ""
 
 #: src/Servebolt/Cli/CloudflareImageResize/CloudflareImageResize.php:120
+#, php-format
 msgid "Cloudflare Image Resize feature already active on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/CloudflareImageResize/CloudflareImageResize.php:123
+#, php-format
 msgid "Cloudflare Image Resize feature activated on site %s."
 msgstr ""
 
@@ -906,10 +987,12 @@ msgid "Cloudflare Image Resize feature is activated."
 msgstr ""
 
 #: src/Servebolt/Cli/CloudflareImageResize/CloudflareImageResize.php:191
+#, php-format
 msgid "Cloudflare Image Resize feature already inactive on site %s."
 msgstr ""
 
 #: src/Servebolt/Cli/CloudflareImageResize/CloudflareImageResize.php:194
+#, php-format
 msgid "Cloudflare Image Resize feature deactivated on site %s."
 msgstr ""
 
@@ -942,19 +1025,22 @@ msgid "No post types specified"
 msgstr ""
 
 #: src/Servebolt/Cli/HtmlCache/HtmlCache.php:402
+#, php-format
 msgid "Default [%s]"
 msgstr ""
 
 #: src/Servebolt/Cli/HtmlCache/HtmlCache.php:407
-#: src/Servebolt/FullPageCache/FullPageCacheHeaders.php:557
+#: src/Servebolt/FullPageCache/FullPageCacheHeaders.php:581
 msgid "All"
 msgstr ""
 
 #: src/Servebolt/Cli/HtmlCache/HtmlCache.php:423
+#, php-format
 msgid "HTML Cache already %s on site %s"
 msgstr ""
 
 #: src/Servebolt/Cli/HtmlCache/HtmlCache.php:426
+#, php-format
 msgid "HTML Cache %s on site %s"
 msgstr ""
 
@@ -975,14 +1061,17 @@ msgid "No IDs were specified."
 msgstr ""
 
 #: src/Servebolt/Cli/HtmlCache/HtmlCache.php:578
+#, php-format
 msgid "The following ids were already excluded: %s"
 msgstr ""
 
 #: src/Servebolt/Cli/HtmlCache/HtmlCache.php:582
+#, php-format
 msgid "The following IDs were invalid: %s"
 msgstr ""
 
 #: src/Servebolt/Cli/HtmlCache/HtmlCache.php:586
+#, php-format
 msgid "Added %s to the list of excluded ids"
 msgstr ""
 
@@ -1115,10 +1204,12 @@ msgid "All tables converted to InnoDB."
 msgstr ""
 
 #: src/Servebolt/DatabaseOptimizer/DatabaseOptimizer.php:458
+#, php-format
 msgid "Added index to table \"%s\""
 msgstr ""
 
 #: src/Servebolt/DatabaseOptimizer/DatabaseOptimizer.php:469
+#, php-format
 msgid "Could not add index to table \"%s\""
 msgstr ""
 
@@ -1131,10 +1222,12 @@ msgid "Could not add index to options table"
 msgstr ""
 
 #: src/Servebolt/DatabaseOptimizer/DatabaseOptimizer.php:870
+#, php-format
 msgid "Converted table \"%s\" to InnoDB"
 msgstr ""
 
 #: src/Servebolt/DatabaseOptimizer/DatabaseOptimizer.php:881
+#, php-format
 msgid "Could not convert table \"%s\" to InnoDB"
 msgstr ""
 
@@ -1148,28 +1241,30 @@ msgstr ""
 
 #: src/Servebolt/Helpers/Helpers.php:58
 #: src/Servebolt/Views/performance-optimizer/advanced/shared-settings/cron-explanation-heading.php:9
+#, php-format
 msgid "To fix this then go to your %ssite settings%s, click \"Settings\" and make sure that the setting \"Environment file in home folder\" is <strong>not</strong> set to \"None\". Remember to click \"Save settings\" to ensure that the file is written to disk regardless of the previous state of the setting."
 msgstr ""
 
 #: src/Servebolt/Helpers/Helpers.php:59
+#, php-format
 msgid "%sGet in touch with our support via chat%s if you need assistance with resolving this issue."
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1254
-#: src/Servebolt/Helpers/Helpers.php:1266
+#: src/Servebolt/Helpers/Helpers.php:1257
+#: src/Servebolt/Helpers/Helpers.php:1269
 #: src/Servebolt/Views/accelerated-domains/image-resize/image-size-index-list.php:12
 msgid "Delete"
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1255
+#: src/Servebolt/Helpers/Helpers.php:1258
 msgid "View"
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1257
+#: src/Servebolt/Helpers/Helpers.php:1260
 msgid "Edit"
 msgstr ""
 
-#: src/Servebolt/Helpers/Helpers.php:1264
+#: src/Servebolt/Helpers/Helpers.php:1267
 msgid "Post does not exist."
 msgstr ""
 
@@ -1289,11 +1384,11 @@ msgstr ""
 msgid "Go to site Accelerated Domains settings"
 msgstr ""
 
-#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:15
+#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:18
 msgid "Accelerated Domains-feature active?"
 msgstr ""
 
-#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:18
+#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:21
 #: src/Servebolt/Views/accelerated-domains/image-resize/settings-form.php:21
 #: src/Servebolt/Views/accelerated-domains/image-resize/settings-form.php:54
 #: src/Servebolt/Views/accelerated-domains/image-resize/settings-form.php:68
@@ -1317,12 +1412,12 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:41
+#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:44
 msgid "Purge CDN cache"
 msgstr ""
 
-#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:42
-msgid "Purge All cache"
+#: src/Servebolt/Views/accelerated-domains/control/settings-form.php:46
+msgid "Purge All caches"
 msgstr ""
 
 #: src/Servebolt/Views/accelerated-domains/image-resize/image-resize.php:19
@@ -1375,6 +1470,7 @@ msgid "The Image Resize feature inside Accelerated Domains enhances the image de
 msgstr ""
 
 #: src/Servebolt/Views/accelerated-domains/image-resize/promo.php:22
+#, php-format
 msgid "The service must be enabled in Accelerated Domains for your site before it can be used. %sPlease get in touch with Servebolt support to get Image Resize enabled%s"
 msgstr ""
 
@@ -1387,6 +1483,7 @@ msgid "The Responsive Images feature inside WordPress allows you to deliver the 
 msgstr ""
 
 #: src/Servebolt/Views/accelerated-domains/image-resize/promo.php:36
+#, php-format
 msgid "%sResponsive images has been supported by WordPress since version 3.3%s, and the Accelerated Domains Image Resize feature improves and enhances the built-in support for responsive images with its optimizations it does on the fly."
 msgstr ""
 
@@ -1521,6 +1618,7 @@ msgid "This feature is using WP Cron to write the prefetch manifest files to the
 msgstr ""
 
 #: src/Servebolt/Views/accelerated-domains/prefetching/settings-form.php:24
+#, php-format
 msgid "Check out %sSuggested optimizations%s for more information about this."
 msgstr ""
 
@@ -1581,6 +1679,7 @@ msgid "Is scheduled for manifest file generation?"
 msgstr ""
 
 #: src/Servebolt/Views/accelerated-domains/prefetching/settings-form.php:98
+#, php-format
 msgid "Yes, at %s."
 msgstr ""
 
@@ -1613,6 +1712,7 @@ msgid "Servebolt API credentials"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/acd-configuration.php:9
+#, php-format
 msgid "The information below is read from %sthe environment file in the Servebolt hosting environment%s."
 msgstr ""
 
@@ -1631,6 +1731,7 @@ msgid "Show password"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/acd-configuration.php:29
+#, php-format
 msgid "For communication with the %sServebolt API%s."
 msgstr ""
 
@@ -1638,12 +1739,8 @@ msgstr ""
 msgid "Environment ID"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cache-purge-triggers.php:6
-msgid "Purge All Cache"
-msgstr ""
-
-#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cache-purge-triggers.php:10
-msgid "Purge Images"
+#: src/Servebolt/Views/cache-settings/cache-purge/configuration/cache-purge-triggers.php:14
+msgid "Purge All Caches"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:8
@@ -1678,6 +1775,7 @@ msgid "How to get your API key"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php:40
+#, php-format
 msgid "Make sure to add permissions for %s when creating a token."
 msgstr ""
 
@@ -1706,6 +1804,7 @@ msgid "Servebolt Optimizer supports cache purging of Cloudflare and Accelerated 
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/configuration.php:16
+#, php-format
 msgid "When purging manually you can purge specific URLs, or even purge the entire cache. Keep in mind that purging the entire cache has a temporary impact on the loading speed for the website visitors, because the cache needs to be rebuilt by requesting fresh content and assets from the origin. %sWhen purging manually the best practice is to purge specific assets or pages by using the purge URL feature.%s"
 msgstr ""
 
@@ -1714,6 +1813,7 @@ msgid "This feature can be set up using WP CLI or with the form below."
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/configuration.php:22
+#, php-format
 msgid "Run %swp servebolt cache-purge --help%s to see available commands."
 msgstr ""
 
@@ -1730,6 +1830,7 @@ msgid "Cache provider"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/configuration.php:55
+#, php-format
 msgid "Cache provider is automatically set when %sAccelerated Domains%s is active."
 msgstr ""
 
@@ -1793,6 +1894,7 @@ msgid "Queue based cache purge"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/configuration/cron-configuration.php:10
+#, php-format
 msgid "Use this feature to trigger cache purge using a queue instead of doing it immediately. The queue system uses the WP Cron and will run every minute. We recommend that you set WordPress up to use the UNIX-based cron. Read about how to achieve this %shere%s."
 msgstr ""
 
@@ -1831,6 +1933,7 @@ msgid "Cache Purge Queue"
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-purge/queue/list.php:6
+#, php-format
 msgid "The list below contains all the posts/URLs that are scheduled for cache purge. The max number of items in the list is %s, the rest will be unavailable for display. The most recently added item can be seen at the bottom of the list.%s Note: If you have more than %s items in the list then that would indicate that there is something wrong with the cron-setup. If so please investigate and/or contact support."
 msgstr ""
 
@@ -1856,12 +1959,6 @@ msgstr ""
 msgid "Go to site HTML Cache Settings"
 msgstr ""
 
-#: src/Servebolt/Views/cache-settings/cache-settings/promo.php:4
-#: src/Servebolt/Views/cache-settings/cache-settings/promo.php:20
-#: src/Servebolt/Views/performance-optimizer/menu-optimizer/promo.php:4
-msgid "Servebolt Control Panel dashboard"
-msgstr ""
-
 #: src/Servebolt/Views/cache-settings/cache-settings/promo.php:11
 msgid "These cache settings let you control the cache headers set by the plugin. The cache headers are used to control how caching works in Accelerated Domains, Cloudflare and the Servebolt Cloud."
 msgstr ""
@@ -1875,6 +1972,7 @@ msgid "Servebolt Cloud HTML Cache (formerly Full Page Cache) is easy to set up, 
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-settings/promo.php:18
+#, php-format
 msgid "To activate HTML Cache to go %s and set \"Caching\" to \"Static Files + Full-Page Cache\"."
 msgstr ""
 
@@ -1887,7 +1985,8 @@ msgid "Accelerated Domains has a optimized cache engine and it respect these set
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-settings/promo.php:38
-msgid "Not running Accelerated Domains? %sOrder Accelerated Domains in the control panel%s and Servebolt Support will add it to your domain and set it up for you."
+#, php-format
+msgid "Not running Accelerated Domains? %sOrder Accelerated Domains in the admin panel%s and Servebolt Support will add it to your domain and set it up for you."
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-settings/promo.php:46
@@ -1895,6 +1994,7 @@ msgid "When Cloudflare is set up to respect origin cache headers, changing these
 msgstr ""
 
 #: src/Servebolt/Views/cache-settings/cache-settings/promo.php:51
+#, php-format
 msgid "%sGet in touch with Servebolt Support%s to get Cloudflare added to your domain and set up correctly."
 msgstr ""
 
@@ -1975,10 +2075,12 @@ msgid "Taxonomy Archives"
 msgstr ""
 
 #: src/Servebolt/Views/cloudflare-image-resize/configration.php:9
+#, php-format
 msgid "This feature will use %sCloudflare Image Resizing%s to resize the images uploaded in WordPress. Note that this is a <strong>beta feature</strong> and might not work as expected."
 msgstr ""
 
 #: src/Servebolt/Views/cloudflare-image-resize/configration.php:10
+#, php-format
 msgid "Cloudflare Image Resize requires your domain to have an active %sCloudflare Business subscription%s, have the Image Resizing feature active, and that your traffic is proxied through Cloudflare."
 msgstr ""
 
@@ -2062,6 +2164,7 @@ msgid "Enable Cloudflare APO support?"
 msgstr ""
 
 #: src/Servebolt/Views/general-settings/settings-form.php:15
+#, php-format
 msgid "To use the Cloudflare APO %s, its no longer possible to use APO without the plugin."
 msgstr ""
 
@@ -2078,37 +2181,38 @@ msgstr ""
 msgid "Add automatic version parameter to asset URLs"
 msgstr ""
 
-#: src/Servebolt/Views/log-viewer/sl7-viewer.php:8
+#: src/Servebolt/Views/log-viewer/log-viewer.php:8
 #: src/Servebolt/Views/log-viewer/sl8-viewer.php:8
 msgid "The log file does not exist."
 msgstr ""
 
-#: src/Servebolt/Views/log-viewer/sl7-viewer.php:11
+#: src/Servebolt/Views/log-viewer/log-viewer.php:11
 #: src/Servebolt/Views/log-viewer/sl8-viewer.php:11
 msgid "Log file is not readable."
 msgstr ""
 
-#: src/Servebolt/Views/log-viewer/sl7-viewer.php:13
+#: src/Servebolt/Views/log-viewer/log-viewer.php:13
 #: src/Servebolt/Views/log-viewer/sl8-viewer.php:13
 msgid "Your error log is empty."
 msgstr ""
 
-#: src/Servebolt/Views/log-viewer/sl7-viewer.php:15
+#: src/Servebolt/Views/log-viewer/log-viewer.php:15
 #: src/Servebolt/Views/log-viewer/sl8-viewer.php:15
+#, php-format
 msgid "This table lists the %s last entries from today's error log"
 msgstr ""
 
-#: src/Servebolt/Views/log-viewer/sl7-viewer.php:19
+#: src/Servebolt/Views/log-viewer/log-viewer.php:19
 #: src/Servebolt/Views/log-viewer/sl8-viewer.php:19
 msgid "Timestamp"
 msgstr ""
 
-#: src/Servebolt/Views/log-viewer/sl7-viewer.php:20
+#: src/Servebolt/Views/log-viewer/log-viewer.php:20
 #: src/Servebolt/Views/log-viewer/sl8-viewer.php:20
 msgid "IP"
 msgstr ""
 
-#: src/Servebolt/Views/log-viewer/sl7-viewer.php:21
+#: src/Servebolt/Views/log-viewer/log-viewer.php:21
 #: src/Servebolt/Views/log-viewer/sl8-viewer.php:21
 msgid "Error"
 msgstr ""
@@ -2138,6 +2242,7 @@ msgid "More options"
 msgstr ""
 
 #: src/Servebolt/Views/performance-optimizer/advanced/settings-form.php:37
+#, php-format
 msgid "Go to %snetwork settings%s for more site-wide options."
 msgstr ""
 
@@ -2199,6 +2304,7 @@ msgid "All the Servebolt recommended indexes exists"
 msgstr ""
 
 #: src/Servebolt/Views/performance-optimizer/database-optimizations/database-optimizations.php:39
+#, php-format
 msgid "Index in the %s table on the %s column"
 msgstr ""
 
@@ -2271,6 +2377,7 @@ msgid "Enabling the menu optimizer speeds up the delivery of menus by multiples.
 msgstr ""
 
 #: src/Servebolt/Views/performance-optimizer/menu-optimizer/promo.php:14
+#, php-format
 msgid "%sLearn more about this settings here%s and %smake sure to test this setting before activating it in production%s."
 msgstr ""
 
@@ -2352,10 +2459,12 @@ msgid "WP Cron is not disabled and is not set up to run on the server cron."
 msgstr ""
 
 #: src/Servebolt/Views/performance-optimizer/performance-optimizer.php:40
+#, php-format
 msgid "WP Cron is disabled %sbut it is not set up to run on the server cron.%s"
 msgstr ""
 
 #: src/Servebolt/Views/performance-optimizer/performance-optimizer.php:42
+#, php-format
 msgid "%sWP Cron is not disabled%s but it is set up to run on the server cron."
 msgstr ""
 
@@ -2364,10 +2473,12 @@ msgid "Read more about cron based configuration <a href=\"https://servebolt.com/
 msgstr ""
 
 #: src/Servebolt/Views/performance-optimizer/performance-optimizer.php:54
+#, php-format
 msgid "To fix this then run WP CLI-command %swp servebolt cron enable%s, or choose to enable \"Run WP Cron from UNIX cron\" from the <a href=\"%s\">Advanced tab</a>"
 msgstr ""
 
 #: src/Servebolt/Views/performance-optimizer/performance-optimizer.php:58
+#, php-format
 msgid "To disable feature then run WP CLI-command %swp servebolt cron disable%s, or choose to disable \"Run WP Cron from UNIX cron\" from the <a href=\"%s\">Advanced tab</a> "
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -60,5 +60,6 @@
     "webpack-cli": "^3.3.2",
     "webpack-rtl-plugin": "^2.0.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/Servebolt/Admin/CachePurgeControl/CachePurgeControl.php
+++ b/src/Servebolt/Admin/CachePurgeControl/CachePurgeControl.php
@@ -100,6 +100,7 @@ class CachePurgeControl
         $queueBasedCachePurgeActiveStateIsOverridden = CachePurge::queueBasedCachePurgeActiveStateIsOverridden();
         $queueBasedCachePurgeIsActive = CachePurge::queueBasedCachePurgeIsActive();
         $automaticCachePurgeIsAvailable = CachePurge::automaticCachePurgeIsAvailable();
+        $cfCacheTagsIsActive = CachePurge::cfCacheTagsIsActive();
 
         view(
             'cache-settings.cache-purge.cache-purge',
@@ -118,6 +119,7 @@ class CachePurgeControl
                 'queueBasedCachePurgeActiveStateIsOverridden',
                 'queueBasedCachePurgeIsActive',
                 'acdLock',
+                'cfCacheTagsIsActive',
             ])
         );
     }
@@ -298,6 +300,7 @@ class CachePurgeControl
             'cache_purge_auto_on_deletion',
             'cache_purge_auto_on_attachment_update',
             'cache_purge_driver',
+            'cf_cache_tags',
             'cf_zone_id',
             'cf_auth_type',
             'cf_email',

--- a/src/Servebolt/Admin/ClearSiteDataHeader/ClearSiteDataHeader.php
+++ b/src/Servebolt/Admin/ClearSiteDataHeader/ClearSiteDataHeader.php
@@ -32,11 +32,12 @@ class ClearSiteDataHeader
 
     public function maybeSetHeader()
     {
-        if (!empty($_COOKIE['clear_site_data']) && 
+        if (
+            $_SERVER['REQUEST_METHOD'] == 'GET' &&
+            !empty($_COOKIE['clear_site_data']) && 
             is_user_logged_in() &&
             $this->get_browser()== 'firefox') {
             header('Clear-Site-Data: "cache", "storage"');
-
             // Clear the cookie immediately after use
             setcookie('clear_site_data', '', time() - 3600, '/', '', is_ssl(), true);
         }

--- a/src/Servebolt/Admin/ClearSiteDataHeader/ClearSiteDataHeader.php
+++ b/src/Servebolt/Admin/ClearSiteDataHeader/ClearSiteDataHeader.php
@@ -10,21 +10,86 @@ if (!defined('ABSPATH')) exit;
  */
 class ClearSiteDataHeader
 {
-    /**
-     * ClearSiteDataHeader constructor.
-     */
     public function __construct()
     {
-        add_action('wp_login', [$this, 'setHeader'], 10, 0);
+        add_action('wp_login', [$this, 'flagLogin'], 10, 2);
+        add_action('template_redirect', [$this, 'maybeSetHeader']);
+        add_action('wp_footer', [$this, 'wp_footer']);
+        add_action('admin_footer', [$this, 'wp_footer']);
+        add_action('login_footer', [$this, 'wp_footer']);
+
     }
 
-    /**
-     * Set header to clear local storage and browser cache during login.
-     */
-    public function setHeader(): void
+    public function flagLogin($user_login, $user)
     {
-        if (apply_filters('sb_optimizer_clear_site_data_header_active', true)) {
+        // Set a transient or cookie to indicate we just logged in
+        setcookie('clear_site_data', '1', time() + 100, '/', '', is_ssl(), true);
+    }
+
+    public function maybeSetHeader()
+    {
+        if (!empty($_COOKIE['clear_site_data']) && 
+            is_user_logged_in() &&
+            $this->get_browser()== 'firefox') {
             header('Clear-Site-Data: "cache", "storage"');
+
+            // Clear the cookie immediately after use
+            setcookie('clear_site_data', '', time() - 3600, '/', '', is_ssl(), true);
         }
+    }
+
+    protected function get_browser($userAgent = null) {
+        if ($userAgent === null) {
+        if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+            return 'unknown';
+        }
+        $userAgent = $_SERVER['HTTP_USER_AGENT'];
+    }
+
+    $userAgent = strtolower($userAgent);
+
+     // Detect Chromium-based browsers
+    if (
+        strpos($userAgent, 'chrome') !== false ||
+        strpos($userAgent, 'crios') !== false ||         // Chrome on iOS
+        strpos($userAgent, 'edg/') !== false ||          // Edge
+        strpos($userAgent, 'opr/') !== false ||          // Opera
+        strpos($userAgent, 'brave') !== false ||         // Brave
+        strpos($userAgent, 'chromium') !== false
+    ) {
+        return 'chrome';
+    }
+
+    if (strpos($userAgent, 'safari') !== false && strpos($userAgent, 'chrome') === false) return 'safari';
+    if (strpos($userAgent, 'firefox') !== false) return 'firefox';
+    if (strpos($userAgent, 'msie') !== false || strpos($userAgent, 'trident/') !== false) return 'internet explorer';
+
+    return 'unknown';
+    }
+
+    function wp_footer() {
+        if (!is_user_logged_in()) return;
+
+        $shouldReload = false;
+        if( defined('SB_OPTIMIZER_CLEAR_CACHE_RELOAD_CHROME') ) {
+            $reload = SB_OPTIMIZER_CLEAR_CACHE_RELOAD_CHROME;
+        }
+
+        ?>
+        <script>
+        (function() {
+            const ua = navigator.userAgent;
+            const isChrome = /Chrome/.test(ua) && !/Edg|OPR|SamsungBrowser|CriOS/.test(ua);
+
+            if (isChrome && document.cookie.includes('clear_cache=1')) {
+                document.cookie = 'clear_cache=1; Max-Age=0; path=/';
+                fetch('/?clear_site_data=1', { credentials: 'include' })
+                    <?php if ($shouldReload): ?>
+                    .then(() => location.reload(true));
+                    <?php endif; ?>
+            }
+        })();
+        </script>
+    <?php
     }
 }

--- a/src/Servebolt/CachePurge/BrowserManagment.php
+++ b/src/Servebolt/CachePurge/BrowserManagment.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Servebolt\Optimizer\CachePurge;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+use Servebolt\Optimizer\Traits\Singleton;
+
+
+/**
+ * Class CachePurge
+ *
+ * This class will resolve the cache purge driver, and forward the cache purge request to it.
+ *
+ * @package Servebolt\Optimizer\CachePurge
+ */
+class BrowserManagment
+{
+    use Singleton;
+
+    /**
+     * Alias for "getInstance".
+     */
+    public static function init(): void
+    {
+        self::getInstance();
+    }
+
+    /**
+     * WpDatabaseMigrations constructor.
+     */
+    public function __construct()
+    {
+        add_action('wp_footer', [$this, 'wp_footer']);
+        add_action('admin_footer', [$this, 'wp_footer']);
+        add_action('login_footer', [$this, 'wp_footer']);
+        add_action('init', [$this, 'clear_chrome_cache']);
+    }
+
+    public function clear_chrome_cache() {
+        if (
+            $_SERVER['REQUEST_METHOD'] == 'GET' &&
+            isset($_GET['clear_site_data']) &&
+            is_user_logged_in() &&
+            $this->get_browser()== 'chrome'
+        ) {
+            header('Clear-Site-Data: "cache", "storage"');
+            header('Content-Type: application/javascript');
+            echo '/* cache cleared */';
+            exit;
+        }
+    }
+
+    protected function get_browser($userAgent = null) {
+        if ($userAgent === null) {
+        if (!isset($_SERVER['HTTP_USER_AGENT'])) {
+            return 'unknown';
+        }
+        $userAgent = $_SERVER['HTTP_USER_AGENT'];
+    }
+
+    $userAgent = strtolower($userAgent);
+
+     // Detect Chromium-based browsers
+    if (
+        strpos($userAgent, 'chrome') !== false ||
+        strpos($userAgent, 'crios') !== false ||         // Chrome on iOS
+        strpos($userAgent, 'edg/') !== false ||          // Edge
+        strpos($userAgent, 'opr/') !== false ||          // Opera
+        strpos($userAgent, 'brave') !== false ||         // Brave
+        strpos($userAgent, 'chromium') !== false
+    ) {
+        return 'chrome';
+    }
+
+    if (strpos($userAgent, 'safari') !== false && strpos($userAgent, 'chrome') === false) return 'safari';
+    if (strpos($userAgent, 'firefox') !== false) return 'firefox';
+    if (strpos($userAgent, 'msie') !== false || strpos($userAgent, 'trident/') !== false) return 'internet explorer';
+
+    return 'unknown';
+    }
+
+    function wp_footer() {
+        $shouldReload = false;
+        if( defined('SB_OPTIMIZER_CLEAR_CACHE_RELOAD_CHROME') ) {
+            $reload = SB_OPTIMIZER_CLEAR_CACHE_RELOAD_CHROME;
+        }
+
+        ?>
+        <script>
+        (function() {
+            if ( /Chrome|Chromium|Edg|OPR|SamsungBrowser|CriOS/.test(navigator.userAgent) && 
+            document.cookie.includes('clear_browser_cache=1')) 
+            {
+                document.cookie = 'clear_browser_cache=1; Max-Age=0; path=/';
+                fetch('/?clear_site_data=1', { credentials: 'include' })
+                    <?php if ($shouldReload): ?>
+                    .then(() => location.reload(true));
+                    <?php endif; ?>
+            }
+        })();
+        </script>
+    <?php
+    }
+}

--- a/src/Servebolt/CachePurge/CachePurge.php
+++ b/src/Servebolt/CachePurge/CachePurge.php
@@ -288,7 +288,7 @@ class CachePurge
     public static function cfCacheTagsIsActive(?int $blogId = null): bool
     {
         return checkboxIsChecked(
-            smartGetOption($blogId, 'cf_cache_tags')
+            smartGetOption($blogId, 'cf_cache_tags', '1')
         );
     }
 

--- a/src/Servebolt/CachePurge/CachePurge.php
+++ b/src/Servebolt/CachePurge/CachePurge.php
@@ -280,6 +280,19 @@ class CachePurge
     }
 
     /**
+     * Whether we should use Cache Tags for Cloudflare
+     *
+     * @param int|null $blogId
+     * @return bool
+     */
+    public static function cfCacheTagsIsActive(?int $blogId = null): bool
+    {
+        return checkboxIsChecked(
+            smartGetOption($blogId, 'cf_cache_tags')
+        );
+    }
+
+    /**
      * Whether we should purge cache automatically when an attachment is updated.
      *
      * @param int|null $blogId

--- a/src/Servebolt/CachePurge/Drivers/Cloudflare.php
+++ b/src/Servebolt/CachePurge/Drivers/Cloudflare.php
@@ -35,7 +35,7 @@ class Cloudflare implements CachePurgeAllInterface, CachePurgeUrlInterface, Cach
             '/wp-admin/',
             '/index.php/',
         ];
-        foreach($never_cached_paths as $never_cached_path) {
+        foreach ($never_cached_paths as $never_cached_path) {
             if (strpos($path, $never_cached_path) !== false) {
                 return false;
             }
@@ -102,6 +102,30 @@ class Cloudflare implements CachePurgeAllInterface, CachePurgeUrlInterface, Cach
             $instance = CloudflareApi::getInstance();
             if ($instance->isConfigured()) {
                 $instance->purgeAll();
+                return true;
+            }
+            return false;
+        } catch (CloudflareSdkApiError $e) {
+            throw new CloudflareApiError(
+                $e->getErrors(),
+                $e->getResponse()
+            );
+        }
+    }
+
+    /**
+     * Purge an array of tags.
+     *
+     * @param array $urls
+     * @return bool
+     * @throws CloudflareApiError
+     */
+    public function purgeByTags(array $tags): bool
+    {
+        try {
+            $instance = CloudflareApi::getInstance();
+            if ($instance->isConfigured()) {
+                $instance->purgeTags($tags);
                 return true;
             }
             return false;

--- a/src/Servebolt/CacheTags/AddCacheTagsHeaders.php
+++ b/src/Servebolt/CacheTags/AddCacheTagsHeaders.php
@@ -12,6 +12,7 @@ use function Servebolt\Optimizer\Helpers\isCron;
 use function Servebolt\Optimizer\Helpers\isTesting;
 use function Servebolt\Optimizer\Helpers\isWpRest;
 use function Servebolt\Optimizer\Helpers\getCondtionalHookPreHeaders;
+use function Servebolt\Optimizer\Helpers\smartGetOption;
 
 /**
  * This class adds cache-tags headers to the HTTP pages of the site. This is then
@@ -69,6 +70,12 @@ class AddCacheTagsHeaders extends CacheTagsBase {
         ) return;
 
         if(in_array($this->driver, CanUseCacheTags::allowedDrivers())) {
+            if($this->driver == 'cloudflare') {
+                if(smartGetOption($blogId, 'cf_cache_tags', false) === false) {
+                    return;
+                }
+            }
+
             // Get the correct hook based on version of WordPress, pre 6.1 wp, post send_headers.
             add_action(getCondtionalHookPreHeaders(), [$this,'addCacheTagsHeaders']);
         }

--- a/src/Servebolt/CacheTags/AddCacheTagsHeaders.php
+++ b/src/Servebolt/CacheTags/AddCacheTagsHeaders.php
@@ -71,7 +71,7 @@ class AddCacheTagsHeaders extends CacheTagsBase {
 
         if(in_array($this->driver, CanUseCacheTags::allowedDrivers())) {
             if($this->driver == 'cloudflare') {
-                if(smartGetOption($blogId, 'cf_cache_tags', false) === false) {
+                if(smartGetOption($blogId, 'cf_cache_tags', '1') !== '1') {
                     return;
                 }
             }

--- a/src/Servebolt/CacheTags/CanUseCacheTags.php
+++ b/src/Servebolt/CacheTags/CanUseCacheTags.php
@@ -6,7 +6,7 @@ class CanUseCacheTags {
 
     static public function allowedDrivers()
     {
-        return ['acd', 'serveboltcdn'];
+        return ['acd', 'serveboltcdn', 'cloudflare'];
     }
 
 }

--- a/src/Servebolt/Cli/Cache/CacheSettings.php
+++ b/src/Servebolt/Cli/Cache/CacheSettings.php
@@ -53,6 +53,7 @@ class CacheSettings extends CliKeyValueStorage
                 'api_key',
             ]
         ],
+        'cf_cache_tags' => 'boolean',
         'cf_email' => 'string',
         'cf_api_key' => 'string',
         'cf_api_token' => 'string',

--- a/src/Servebolt/Helpers/Helpers.php
+++ b/src/Servebolt/Helpers/Helpers.php
@@ -729,6 +729,7 @@ function getAllOptionsNames(bool $includeMigrationOptions = false): array
         'cache_purge_auto_on_slug_change',
         'cache_purge_auto_on_deletion',
         'cache_purge_driver',
+        'cf_cache_tags',
         'cf_switch',
         'cf_zone_id',
         'cf_auth_type',

--- a/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
+++ b/src/Servebolt/Sdk/Cloudflare/ApiMethods/CachePurge.php
@@ -115,6 +115,34 @@ trait CachePurge
         }
     }
 
+     /**
+     * Purge one or more tags in a zone.
+     *
+     * @param array $tags
+     * @return bool
+     * @throws ApiError
+     */
+    public function purgeTags(array $tags): bool
+    {
+
+        $zoneId = $this->getZoneId();
+        if (!$zoneId) {
+            return false;
+        }
+
+        $response = $this->request('zones/' . $zoneId . '/purge_cache', 'POST', [
+            'tags' => $tags,
+        ]);
+        if ($this->wasSuccessful($response)) {
+            return true;
+        } else {
+            throw new ApiError(
+                ApiRequestHelpers::getErrorsFromRequest($response),
+                $response
+            );
+        }
+    }
+
     /**
      * Check whether the request was succesful.
      *

--- a/src/Servebolt/ServeboltOptimizer.php
+++ b/src/Servebolt/ServeboltOptimizer.php
@@ -29,6 +29,7 @@ use Servebolt\Optimizer\WpCron\WpCronEvents;
 use Servebolt\Optimizer\CacheTags\AddCacheTagsHeaders;
 use Servebolt\Optimizer\MaintenanceTasks\ServeboltEventsHandler;
 use Servebolt\Optimizer\HttpHeaders\Static404;
+use Servebolt\Optimizer\CachePurge\BrowserManagment;
 use function Servebolt\Optimizer\Helpers\featureIsActive;
 use function Servebolt\Optimizer\Helpers\featureIsAvailable;
 use function Servebolt\Optimizer\Helpers\isCli;
@@ -91,6 +92,8 @@ class ServeboltOptimizer
             if(!defined('SERVEBOLT_SDK_BASE_URI')) {
                 define('SERVEBOLT_SDK_BASE_URI', getApiUrlFromEnvFile());
             }
+
+            BrowserManagment::init();
 
         }
 

--- a/src/Servebolt/Utils/DatabaseMigration/Migrations/8_CacheTagsControl.php
+++ b/src/Servebolt/Utils/DatabaseMigration/Migrations/8_CacheTagsControl.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Servebolt\Optimizer\Utils\DatabaseMigration\Migrations;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+use Servebolt\Optimizer\CachePurge\WordPressCachePurge\WordPressCachePurge;
+use Servebolt\Optimizer\Utils\DatabaseMigration\AbstractMigration;
+use Servebolt\Optimizer\Utils\DatabaseMigration\MigrationInterface;
+use function Servebolt\Optimizer\Helpers\isHostedAtServebolt;
+use function Servebolt\Optimizer\Helpers\isAjax;
+use function Servebolt\Optimizer\Helpers\isCli;
+use function Servebolt\Optimizer\Helpers\isCron;
+use function Servebolt\Optimizer\Helpers\isTesting;
+use function Servebolt\Optimizer\Helpers\isWpRest;
+use function Servebolt\Optimizer\Helpers\smartUpdateOption;
+use function Servebolt\Optimizer\Helpers\getOptionName;
+
+/**
+ * Class AddParentIdIndexToQueueTable
+ * @package Servebolt\Optimizer\Utils\DatabaseMigration\Migrations
+ */
+class CacheTagsControl extends AbstractMigration implements MigrationInterface
+{
+    /**
+     * Set a blog suffix for tags.
+     *
+     * @var string
+     */
+    protected $blogId = null;
+    /**
+     * Whether to use the function "dbDelta" when running queries.
+     *
+     * @var bool
+     */
+    protected $useDbDelta = false;
+
+    /**
+     * @var bool Whether the migration is active (optional, defaults to true if omitted).
+     */
+    public static $active = true;
+
+    /**
+     * @var string Table name (optional).
+     */
+    protected $tableName = 'options';
+
+    /**
+     * @var string The plugin version number that this migration belongs to.
+     * 
+     * @since 3.5.11 this is now the db version, number greater than 100
+     * @see getCurrentDatabaseVersion() in helpers and const SERVEBOLT_PLUGIN_DB_VERSION
+     */
+    public static $version = '104';
+
+    protected function setBlog()
+    {
+        if (is_multisite()) {
+            $this->blogId = get_current_blog_id();
+        }
+    }
+
+    /**
+     * Migrate up.
+     *
+     * cache purge if on servebolt and a ACD/CDN customer.
+     */
+    public function up(): void
+    {
+        // if (
+        //     isAjax()
+        //     || isCron()
+        //     || isCli()
+        //     || isWpRest()
+        //     || isTesting()
+        // ) return;
+
+        if(!isHostedAtServebolt()) return;
+
+        $this->setBlog();
+
+        smartUpdateOption($this->blogId, 'cf_cache_tags', 0, true);
+    }
+
+    /**
+     * Return false so that it runs. 
+     *
+     * @return bool
+     */
+    public function hasBeenRun($migrationMethod): bool
+    {        
+        switch($migrationMethod) {
+            case 'up':
+            case 'down':
+                return false;
+        }
+    }
+
+    /**
+     * Migrate down.
+     * 
+     * do nothing, here for interface needs
+     */
+    public function down(): void
+    {
+        // 
+    }
+}

--- a/src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php
+++ b/src/Servebolt/Views/cache-settings/cache-purge/configuration/cloudflare-configuration.php
@@ -1,13 +1,28 @@
-<?php if (!defined('ABSPATH')) exit; // Exit if accessed directly ?>
-<?php use function Servebolt\Optimizer\Helpers\getOptionName; ?>
+<?php if (!defined('ABSPATH')) exit; // Exit if accessed directly 
+?>
+<?php
+
+use function Servebolt\Optimizer\Helpers\getOptionName; ?>
 <?php $cfApi = Servebolt\Optimizer\Api\Cloudflare\Cloudflare::getInstance(); ?>
 
 <tbody class="sb-config-field-general sb-config-field-cloudflare <?php if (!$cachePurgeIsActive || $settings['cache_purge_driver'] !== 'cloudflare') echo 'sb-config-field-hidden'; ?>">
     <tr>
         <th scope="row" colspan="100%" style="padding-bottom: 5px;">
             <h3 style="margin-bottom: 0;"><?php _e('Cloudflare API', 'servebolt-wp'); ?></h3>
-            <p style="font-weight: normal;"><?php _e('Servebolt Optimizer connects to the Cloudflare cache through the Cloudflare API. Best practice is to use API token for authentication.', 'servebolt-wp');?></p>
+            <p style="font-weight: normal;"><?php _e('Servebolt Optimizer connects to the Cloudflare cache through the Cloudflare API. Best practice is to use API token for authentication.', 'servebolt-wp'); ?></p>
         </th>
+    </tr>
+    <tr>
+        <th scope="row"><?php _e('Cache-Tags', 'servebolt-wp'); ?></th>
+        <td>
+            <fieldset>
+                <legend class="screen-reader-text"><span><?php _e('Use Cache Tags', 'servebolt-wp'); ?></span></legend>
+                <label for="cf_cache_tags">
+                    <input name="<?php echo getOptionName('cf_cache_tags'); ?>" type="checkbox" id="cf_cache_tags" value="1" <?php checked($cfCacheTagsIsActive); ?>>
+                    <?php _e('Enable', 'servebolt-wp'); ?>
+                </label><br>
+            </fieldset>
+        </td>
     </tr>
     <tr>
         <th scope="row"><?php _e('Authentication type', 'servebolt-wp'); ?></th>
@@ -25,7 +40,7 @@
             </fieldset>
         </td>
     </tr>
-    <tr class="feature_cf_auth_type-api_token"<?php if ( $settings['cf_auth_type'] != 'api_token' ) echo ' style="display: none;"' ?>>
+    <tr class="feature_cf_auth_type-api_token" <?php if ($settings['cf_auth_type'] != 'api_token') echo ' style="display: none;"' ?>>
         <th scope="row"><label for="sb_cf_api_token"><?php _e('API token', 'servebolt-wp'); ?></label></th>
         <td>
 
@@ -40,14 +55,14 @@
             <p><small><?php echo sprintf(__('Make sure to add permissions for %s when creating a token.', 'servebolt-wp'), $cfApi->apiPermissionsNeeded()); ?></small></p>
         </td>
     </tr>
-    <tr class="feature_cf_auth_type-api_key"<?php if ( $settings['cf_auth_type'] != 'api_key' ) echo ' style="display: none;"' ?>>
+    <tr class="feature_cf_auth_type-api_key" <?php if ($settings['cf_auth_type'] != 'api_key') echo ' style="display: none;"' ?>>
         <th scope="row"><label for="sb_cf_email"><?php _e('Cloudflare e-mail', 'servebolt-wp'); ?></label></th>
         <td>
             <input name="<?php echo getOptionName('cf_email'); ?>" type="text" id="sb_cf_email" autocomplete="off" data-original-value="<?php echo esc_attr($settings['cf_email']); ?>" value="<?php echo esc_attr($settings['cf_email']); ?>" class="regular-text validate-field validation-input-email validation-group-api_key_credentials validation-group-api_credentials">
             <p class="invalid-message"></p>
         </td>
     </tr>
-    <tr class="feature_cf_auth_type-api_key"<?php if ( $settings['cf_auth_type'] != 'api_key' ) echo ' style="display: none;"' ?>>
+    <tr class="feature_cf_auth_type-api_key" <?php if ($settings['cf_auth_type'] != 'api_key') echo ' style="display: none;"' ?>>
         <th scope="row"><label for="sb_cf_api_key"><?php _e('API key', 'servebolt-wp'); ?></label></th>
         <td>
             <div class="sb-pwd">
@@ -69,13 +84,13 @@
             <span class="spinner zone-loading-spinner"></span>
             <p class="invalid-message"></p>
 
-            <p class="active-zone"<?php if ( ! isset($selectedCfZone) || ! $selectedCfZone ) echo ' style="display: none;"'; ?>><?php _e('Selected zone:', 'servebolt-wp'); ?> <span><?php if ( isset($selectedCfZone) && $selectedCfZone ) echo $selectedCfZone->name; ?></span></p>
+            <p class="active-zone" <?php if (! isset($selectedCfZone) || ! $selectedCfZone) echo ' style="display: none;"'; ?>><?php _e('Selected zone:', 'servebolt-wp'); ?> <span><?php if (isset($selectedCfZone) && $selectedCfZone) echo $selectedCfZone->name; ?></span></p>
 
-            <div class="zone-selector-container"<?php if ( ! $haveZones ) echo ' style="display: none;"'; ?>>
+            <div class="zone-selector-container" <?php if (! $haveZones) echo ' style="display: none;"'; ?>>
                 <p style="margin-top: 10px;"><?php _e('Available zones:', 'servebolt-wp'); ?></p>
                 <ul class="zone-selector" style="margin: 5px 0;">
                     <?php if ($haveZones) : ?>
-                        <?php foreach($cfZones as $cfZone) : ?>
+                        <?php foreach ($cfZones as $cfZone) : ?>
                             <li><a href="#" data-name="<?php echo esc_attr($cfZone->name); ?>" data-id="<?php echo esc_attr($cfZone->id); ?>"><?php echo $cfZone->name; ?> (<?php echo $cfZone->id; ?>)</a></li>
                         <?php endforeach; ?>
                     <?php endif; ?>


### PR DESCRIPTION
Still some work to be done
 - Check migration
 - Cloudflare is CachePurge default driver. So cache-tags will be used even if Cloudflare is not configured on a fresh install. Because we set CacheTags to be enabled on fresh installs